### PR TITLE
Added a couple of new convenience methods to core, cleaned up some docs and formatting.

### DIFF
--- a/service/service_registry.go
+++ b/service/service_registry.go
@@ -1,153 +1,156 @@
-// Copyright 2019-2020 VMware, Inc.
+// Copyright 2019-2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package service
 
 import (
-    "github.com/vmware/transport-go/bus"
-    "sync"
-    "fmt"
-    "github.com/vmware/transport-go/model"
-    "log"
+	"fmt"
+	"github.com/vmware/transport-go/bus"
+	"github.com/vmware/transport-go/model"
+	"log"
+	"sync"
 )
 
-// Registry with all local fabric services.
+// ServiceRegistry is the registry for  all local fabric services.
 type ServiceRegistry interface {
-    // Registers a new fabric service and associates it with a given EventBus channel.
-    // Only one fabric service can be associated with a given channel.
-    // If the fabric service implements the FabricInitializableService interface
-    // its Init method will be called during the registration process.
-    RegisterService(service FabricService, serviceChannelName string) error
-    // Unregisters the fabric service associated with the given channel.
-    UnregisterService(serviceChannelName string) error
-    // Set global base host or host:port to be used by the restService
-    SetGlobalRestServiceBaseHost(host string)
+
+	// RegisterService registers a new fabric service and associates it with a given EventBus channel.
+	// Only one fabric service can be associated with a given channel.
+	// If the fabric service implements the FabricInitializableService interface
+	// its Init method will be called during the registration process.
+	RegisterService(service FabricService, serviceChannelName string) error
+
+	// UnregisterService unregisters the fabric service associated with the given channel.
+	UnregisterService(serviceChannelName string) error
+
+	// SetGlobalRestServiceBaseHost sets the global base host or host:port to be used by the restService
+	SetGlobalRestServiceBaseHost(host string)
 }
 
 type serviceRegistry struct {
-    lock sync.Mutex
-    services map[string]*fabricServiceWrapper
-    bus bus.EventBus
+	lock     sync.Mutex
+	services map[string]*fabricServiceWrapper
+	bus      bus.EventBus
 }
 
 var once sync.Once
 var registry ServiceRegistry
 
 func GetServiceRegistry() ServiceRegistry {
-    once.Do(func() {
-        registry = NewServiceRegistry(bus.GetBus())
-    })
-    return registry
+	once.Do(func() {
+		registry = NewServiceRegistry(bus.GetBus())
+	})
+	return registry
 }
 
 func NewServiceRegistry(bus bus.EventBus) ServiceRegistry {
-    registry := &serviceRegistry{
-        bus: bus,
-        services: make(map[string]*fabricServiceWrapper),
-    }
-    // auto-register the restService
-    registry.RegisterService(&restService{}, restServiceChannel)
-    return registry
+	registry := &serviceRegistry{
+		bus:      bus,
+		services: make(map[string]*fabricServiceWrapper),
+	}
+	// auto-register the restService
+	registry.RegisterService(&restService{}, restServiceChannel)
+	return registry
 }
 
 func (r *serviceRegistry) SetGlobalRestServiceBaseHost(host string) {
-    r.services[restServiceChannel].service.(*restService).setBaseHost(host)
+	r.services[restServiceChannel].service.(*restService).setBaseHost(host)
 }
 
 func (r *serviceRegistry) RegisterService(service FabricService, serviceChannelName string) error {
-    r.lock.Lock()
-    defer r.lock.Unlock()
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
-    if service == nil {
-        return fmt.Errorf("unable to register service: nil service")
-    }
+	if service == nil {
+		return fmt.Errorf("unable to register service: nil service")
+	}
 
-    if _, ok := r.services[serviceChannelName]; ok {
-        return fmt.Errorf("unable to register service: service channel name is already used: %s", serviceChannelName)
-    }
+	if _, ok := r.services[serviceChannelName]; ok {
+		return fmt.Errorf("unable to register service: service channel name is already used: %s", serviceChannelName)
+	}
 
-    sw := newServiceWrapper(r.bus, service, serviceChannelName)
-    err := sw.init()
-    if err != nil {
-        return err
-    }
+	sw := newServiceWrapper(r.bus, service, serviceChannelName)
+	err := sw.init()
+	if err != nil {
+		return err
+	}
 
-    r.services[serviceChannelName] = sw
-    return nil
+	r.services[serviceChannelName] = sw
+	return nil
 }
 
 func (r *serviceRegistry) UnregisterService(serviceChannelName string) error {
-    r.lock.Lock()
-    defer r.lock.Unlock()
-    sw, ok := r.services[serviceChannelName]
-    if !ok {
-        return fmt.Errorf("unable to unregister service: no service is registered for channel \"%s\"", serviceChannelName)
-    }
-    sw.unregister()
-    delete(r.services, serviceChannelName)
-    return nil
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	sw, ok := r.services[serviceChannelName]
+	if !ok {
+		return fmt.Errorf("unable to unregister service: no service is registered for channel \"%s\"", serviceChannelName)
+	}
+	sw.unregister()
+	delete(r.services, serviceChannelName)
+	return nil
 }
 
 type fabricServiceWrapper struct {
-    service            FabricService
-    fabricCore         *fabricCore
-    requestMsgHandler  bus.MessageHandler
+	service           FabricService
+	fabricCore        *fabricCore
+	requestMsgHandler bus.MessageHandler
 }
 
 func newServiceWrapper(
-        bus bus.EventBus, service FabricService, serviceChannelName string) *fabricServiceWrapper {
+	bus bus.EventBus, service FabricService, serviceChannelName string) *fabricServiceWrapper {
 
-    return &fabricServiceWrapper{
-        service: service,
-        fabricCore: &fabricCore{
-            bus:         bus,
-            channelName: serviceChannelName,
-        },
-    }
+	return &fabricServiceWrapper{
+		service: service,
+		fabricCore: &fabricCore{
+			bus:         bus,
+			channelName: serviceChannelName,
+		},
+	}
 }
 
 func (sw *fabricServiceWrapper) init() error {
-    sw.fabricCore.bus.GetChannelManager().CreateChannel(sw.fabricCore.channelName)
+	sw.fabricCore.bus.GetChannelManager().CreateChannel(sw.fabricCore.channelName)
 
-    initializationService, ok := sw.service.(FabricInitializableService)
-    if ok {
-        initializationErr := initializationService.Init(sw.fabricCore)
-        if initializationErr != nil {
-            return initializationErr
-        }
-    }
+	initializationService, ok := sw.service.(FabricInitializableService)
+	if ok {
+		initializationErr := initializationService.Init(sw.fabricCore)
+		if initializationErr != nil {
+			return initializationErr
+		}
+	}
 
-    mh, err := sw.fabricCore.bus.ListenRequestStream(sw.fabricCore.channelName)
-    if err != nil {
-        return err
-    }
+	mh, err := sw.fabricCore.bus.ListenRequestStream(sw.fabricCore.channelName)
+	if err != nil {
+		return err
+	}
 
-    sw.requestMsgHandler = mh
-    mh.Handle(
-        func(message *model.Message) {
-            requestPtr, ok := message.Payload.(*model.Request)
-            if !ok {
-                request, ok := message.Payload.(model.Request)
-                if !ok {
-                    log.Println("cannot cast service request payload to model.Request")
-                    return
-                }
-                requestPtr = &request
-            }
+	sw.requestMsgHandler = mh
+	mh.Handle(
+		func(message *model.Message) {
+			requestPtr, ok := message.Payload.(*model.Request)
+			if !ok {
+				request, ok := message.Payload.(model.Request)
+				if !ok {
+					log.Println("cannot cast service request payload to model.Request")
+					return
+				}
+				requestPtr = &request
+			}
 
-            if message.DestinationId != nil {
-                requestPtr.Id = message.DestinationId
-            }
+			if message.DestinationId != nil {
+				requestPtr.Id = message.DestinationId
+			}
 
-            sw.service.HandleServiceRequest(requestPtr, sw.fabricCore)
-        },
-        func(e error) {})
+			sw.service.HandleServiceRequest(requestPtr, sw.fabricCore)
+		},
+		func(e error) {})
 
-    return nil
+	return nil
 }
 
 func (sw *fabricServiceWrapper) unregister() {
-    if sw.requestMsgHandler != nil {
-        sw.requestMsgHandler.Close()
-    }
+	if sw.requestMsgHandler != nil {
+		sw.requestMsgHandler.Close()
+	}
 }

--- a/transport.go
+++ b/transport.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 VMware, Inc.
+// Copyright 2019-2021 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
 package main
@@ -45,28 +45,28 @@ func main() {
 				return nil
 			},
 		},
-		{
-			Name:  "cal",
-			Usage: "Call Calendar service for the time on appfabric.vmware.com",
-			Action: func(c *cli.Context) error {
-				runDemoCal()
-				return nil
-			},
-		},
-		{
-			Name:  "vm-service",
-			Usage: "Call VmService to create and Power on a new VM on appfabric.vmware.com",
-			Action: func(c *cli.Context) error {
-				runDemoVmService(c)
-				return nil
-			},
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "localhost",
-					Usage: "Connect to localhost:8090 instead of appfabric.vmware.com",
-				},
-			},
-		},
+		//{
+		//	Name:  "cal",
+		//	Usage: "Call Calendar service for the time on appfabric.vmware.com",
+		//	Action: func(c *cli.Context) error {
+		//		runDemoCal()
+		//		return nil
+		//	},
+		//},
+		//{
+		//	Name:  "vm-service",
+		//	Usage: "Call VmService to create and Power on a new VM on appfabric.vmware.com",
+		//	Action: func(c *cli.Context) error {
+		//		runDemoVmService(c)
+		//		return nil
+		//	},
+		//	Flags: []cli.Flag{
+		//		&cli.BoolFlag{
+		//			Name:  "localhost",
+		//			Usage: "Connect to localhost:8090 instead of appfabric.vmware.com",
+		//		},
+		//	},
+		//},
 		{
 			Name:  "service",
 			Usage: "Run Service - Run local service",
@@ -81,27 +81,27 @@ func main() {
 				return nil
 			},
 		},
-		{
-			Name:  "store",
-			Usage: "Open galactic store from appfabric.vmware.com",
-			Action: func(c *cli.Context) error {
-				runDemoStore(c)
-				return nil
-			},
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "localhost",
-					Usage: "Connect to localhost:8090 instead of appfabric.vmware.com",
-				},
-			},
-		},
+		//{
+		//	Name:  "store",
+		//	Usage: "Open galactic store from appfabric.vmware.com",
+		//	Action: func(c *cli.Context) error {
+		//		runDemoStore(c)
+		//		return nil
+		//	},
+		//	Flags: []cli.Flag{
+		//		&cli.BoolFlag{
+		//			Name:  "localhost",
+		//			Usage: "Connect to localhost:8090 instead of appfabric.vmware.com",
+		//		},
+		//	},
+		//},
 		{
 			Name:  "fabric-services",
 			Usage: "Starts a couple of demo fabric services locally",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "localhost",
-					Usage: "Use localhost Bifrost broker",
+					Usage: "Use localhost transport broker",
 				},
 			},
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
core fabric methods for errors added to allow payload and headers to be submitted. Also cleaned up some of the godoc in the service package. No breaking functionality. Also turned on `go fmt`, seems to have updated most of the `service_registry`

Signed-off-by: Dave Shanley <dshanley@vmware.com>