### PR TITLE
Install gocov dependency before go install

### DIFF
--- a/.github/workflows/transport-postmerge.yml
+++ b/.github/workflows/transport-postmerge.yml
@@ -13,9 +13,11 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
+          go-version: '^1.16'
       - run: go get ./...
       - run: |
+          go get github.com/axw/gocov/gocov
+          go get github.com/AlekSi/gocov-xml
           go install github.com/axw/gocov/gocov
           go install github.com/AlekSi/gocov-xml
       - run: |

--- a/.github/workflows/transport-premerge.yml
+++ b/.github/workflows/transport-premerge.yml
@@ -11,9 +11,11 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
+          go-version: '^1.16'
       - run: go get ./...
       - run: |
+          go get github.com/axw/gocov/gocov
+          go get github.com/AlekSi/gocov-xml
           go install github.com/axw/gocov/gocov
           go install github.com/AlekSi/gocov-xml
       - run: |


### PR DESCRIPTION
This fixes the broken CI/CD pipeline by explicitly installing gocov dependency before invoking go install