### PR TITLE
Implement service lifecycle manager for Plank

### DIFF
--- a/service/service_lifecycle_manager.go
+++ b/service/service_lifecycle_manager.go
@@ -28,9 +28,11 @@ type ServiceLifecycleHookEnabled interface {
 }
 
 type RESTBridgeConfig struct {
-	ServiceChannel string
-	Uri string
-	Method string
+	ServiceChannel       string
+	Uri                  string
+	Method               string
+	AllowHead            bool
+	AllowOptions         bool
 	FabricRequestBuilder func(w http.ResponseWriter, r *http.Request) model.Request
 }
 

--- a/service/service_lifecycle_manager.go
+++ b/service/service_lifecycle_manager.go
@@ -57,7 +57,7 @@ func (lm *serviceLifecycleManager) GetServiceHooks(serviceChannelName string) Se
 func (lm *serviceLifecycleManager) OverrideRESTBridgeConfig(serviceChannelName string, config []*RESTBridgeConfig) error {
 	_, err := lm.serviceRegistryRef.GetService(serviceChannelName)
 	if err != nil {
-		return nil
+		return err
 	}
 	reg := lm.serviceRegistryRef.(*serviceRegistry)
 	if err = reg.bus.SendResponseMessage(

--- a/service/service_lifecycle_manager.go
+++ b/service/service_lifecycle_manager.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"fmt"
+	"github.com/vmware/transport-go/bus"
+	"github.com/vmware/transport-go/model"
+	"net/http"
+	"sync"
+)
+
+var svcLifecycleManagerInstance ServiceLifecycleManager
+
+type LifecycleHookNotImplementedError struct {
+}
+
+func (e *LifecycleHookNotImplementedError) Error() string {
+	return fmt.Sprintf("service does not implement lifecycle hook interface")
+}
+
+type ServiceLifecycleManager interface {
+	GetServiceHooks(serviceChannelName string) (ServiceLifecycleHookEnabled, error)
+}
+
+type ServiceLifecycleHookEnabled interface {
+	OnServiceReady() chan struct{} // service initialization logic should be implemented here
+	OnServerShutdown() // teardown logic goes here and will be automatically invoked on graceful server shutdown
+	GetRESTBridgeConfig() []*RESTBridgeConfig // service-to-REST endpoint mappings go here
+}
+
+type RESTBridgeConfig struct {
+	ServiceChannel string
+	Uri string
+	Method string
+	FabricRequestBuilder func(w http.ResponseWriter, r *http.Request) model.Request
+}
+
+type serviceLifecycleManager struct {
+	busRef bus.EventBus
+	serviceRegistryRef ServiceRegistry
+	mu       sync.Mutex
+}
+
+func (lm *serviceLifecycleManager) GetServiceHooks(serviceChannelName string) (ServiceLifecycleHookEnabled, error) {
+	service, err := lm.serviceRegistryRef.GetService(serviceChannelName)
+	if err != nil {
+		return nil, err
+	}
+
+	if lifecycleHookEnabled, ok := service.(ServiceLifecycleHookEnabled); ok {
+		return lifecycleHookEnabled, nil
+	}
+	return nil, &LifecycleHookNotImplementedError{}
+}
+
+// GetServiceLifecycleManager returns a singleton instance of ServiceLifecycleManager
+func GetServiceLifecycleManager(bus bus.EventBus, serviceRegistry ServiceRegistry) ServiceLifecycleManager {
+	if svcLifecycleManagerInstance == nil {
+		svcLifecycleManagerInstance = &serviceLifecycleManager{
+			busRef:   bus,
+			serviceRegistryRef: serviceRegistry,
+			mu:       sync.Mutex{},
+		}
+	}
+	return svcLifecycleManagerInstance
+}

--- a/service/service_lifecycle_manager.go
+++ b/service/service_lifecycle_manager.go
@@ -13,7 +13,7 @@ type ServiceLifecycleManager interface {
 }
 
 type ServiceLifecycleHookEnabled interface {
-	OnServiceReady() chan struct{}            // service initialization logic should be implemented here
+	OnServiceReady() chan bool            // service initialization logic should be implemented here
 	OnServerShutdown()                        // teardown logic goes here and will be automatically invoked on graceful server shutdown
 	GetRESTBridgeConfig() []*RESTBridgeConfig // service-to-REST endpoint mappings go here
 }

--- a/service/service_lifecycle_manager_test.go
+++ b/service/service_lifecycle_manager_test.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestServiceLifecycleManager(t *testing.T) {
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+	assert.NotNil(t, lcm)
+}
+
+func TestServiceLifecycleManager_GetServiceHooks(t *testing.T) {
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+	svc := &mockLifecycleHookEnabledService{}
+	sr.RegisterService(svc, "another-test-channel")
+	hooks := lcm.GetServiceHooks("another-test-channel")
+	assert.NotNil(t, hooks)
+}
+
+func TestServiceLifecycleManager_GetServiceHooks_NoSuchService(t *testing.T) {
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+	hooks := lcm.GetServiceHooks("i-don-t-exist")
+	assert.Nil(t, hooks)
+}
+
+func TestServiceLifecycleManager_GetServiceHooks_LifecycleHooksNotImplemented(t *testing.T) {
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+	svc := &mockInitializableService{}
+	sr.RegisterService(svc, "test-channel")
+	hooks := lcm.GetServiceHooks("test-channel")
+	assert.Nil(t, hooks)
+}

--- a/service/service_lifecycle_manager_test.go
+++ b/service/service_lifecycle_manager_test.go
@@ -2,36 +2,110 @@ package service
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/transport-go/model"
+	"net/http"
 	"testing"
 )
 
 func TestServiceLifecycleManager(t *testing.T) {
+	// arrange
 	sr := newTestServiceRegistry()
+
+	// act
 	lcm := newTestServiceLifecycleManager(sr)
+
+	// assert
 	assert.NotNil(t, lcm)
 }
 
 func TestServiceLifecycleManager_GetServiceHooks(t *testing.T) {
+	// arrange
 	sr := newTestServiceRegistry()
 	lcm := newTestServiceLifecycleManager(sr)
 	svc := &mockLifecycleHookEnabledService{}
 	sr.RegisterService(svc, "another-test-channel")
+
+	// act
 	hooks := lcm.GetServiceHooks("another-test-channel")
+
+
+	// assert
 	assert.NotNil(t, hooks)
 }
 
 func TestServiceLifecycleManager_GetServiceHooks_NoSuchService(t *testing.T) {
+	// arrange
 	sr := newTestServiceRegistry()
 	lcm := newTestServiceLifecycleManager(sr)
+
+	// act
 	hooks := lcm.GetServiceHooks("i-don-t-exist")
+
+	// assert
 	assert.Nil(t, hooks)
 }
 
 func TestServiceLifecycleManager_GetServiceHooks_LifecycleHooksNotImplemented(t *testing.T) {
+	// arrange
 	sr := newTestServiceRegistry()
 	lcm := newTestServiceLifecycleManager(sr)
 	svc := &mockInitializableService{}
 	sr.RegisterService(svc, "test-channel")
+
+	// act
 	hooks := lcm.GetServiceHooks("test-channel")
+
+	// assert
 	assert.Nil(t, hooks)
+}
+
+func TestServiceLifecycleManager_OverrideRESTBridgeConfig_NoSuchService(t *testing.T) {
+	// arrange
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+
+	// act
+	err := lcm.OverrideRESTBridgeConfig("no-such-service", []*RESTBridgeConfig{})
+
+	// assert
+	assert.NotNil(t, err)
+}
+
+func TestServiceLifecycleManager_OverrideRESTBridgeConfig(t *testing.T) {
+	// arrange
+	sr := newTestServiceRegistry()
+	lcm := newTestServiceLifecycleManager(sr)
+	sr.lifecycleManager = lcm.(*serviceLifecycleManager)
+	_ = sr.RegisterService(&mockLifecycleHookEnabledService{}, "another-test-channel")
+
+	// arrange: test payload
+	payload := &RESTBridgeConfig{
+		ServiceChannel:       "another-test-channel",
+		Uri:                  "/rest/new-uri",
+		Method:               http.MethodGet,
+		AllowHead:            false,
+		AllowOptions:         false,
+		FabricRequestBuilder: nil,
+	}
+
+	// arrange: set up a handler to expect to receive a payload that matches the test payload set above
+	stream, err := sr.bus.ListenStreamForDestination(LifecycleManagerChannelName, sr.bus.GetId())
+	assert.Nil(t, err)
+	defer stream.Close()
+	stream.Handle(func(message *model.Message) {
+		req, parsed := message.Payload.(*SetupRESTBridgeRequest)
+		if !parsed {
+			assert.Fail(t, "should have expected *SetupRESTBridgeRequest payload")
+		}
+		// assert
+		assert.True(t, req.Override)
+		assert.EqualValues(t, "another-test-channel", req.ServiceChannel)
+		assert.EqualValues(t, payload, req)
+	}, func(err error) {
+		assert.Fail(t, "should not have errored", err)
+	})
+
+	// act
+	err = lcm.OverrideRESTBridgeConfig("another-test-channel", []*RESTBridgeConfig{payload})
+	assert.Nil(t, err)
 }

--- a/service/service_registry.go
+++ b/service/service_registry.go
@@ -128,7 +128,9 @@ func (r *serviceRegistry) RegisterService(service FabricService, serviceChannelN
 	// hand off registering REST bridges to Plank via bus messages
 	if hooks = lcm.GetServiceHooks(serviceChannelName); hooks != nil {
 		if err = bus.GetBus().SendResponseMessage(
-			LifecycleManagerChannelName, hooks.GetRESTBridgeConfig(), bus.GetBus().GetId()); err != nil {
+			LifecycleManagerChannelName,
+			&SetupRESTBridgeRequest{Config: hooks.GetRESTBridgeConfig()},
+			bus.GetBus().GetId()); err != nil {
 			return err
 		}
 	}

--- a/service/service_registry.go
+++ b/service/service_registry.go
@@ -11,8 +11,12 @@ import (
 	"sync"
 )
 
+const LifecycleManagerChannelName = "service-lifecycle-manager"
+
 // ServiceRegistry is the registry for  all local fabric services.
 type ServiceRegistry interface {
+	// GetAllServiceChannels returns all active Fabric service channels as a slice of strings
+	GetAllServiceChannels() []string
 
 	// RegisterService registers a new fabric service and associates it with a given EventBus channel.
 	// Only one fabric service can be associated with a given channel.
@@ -25,6 +29,9 @@ type ServiceRegistry interface {
 
 	// SetGlobalRestServiceBaseHost sets the global base host or host:port to be used by the restService
 	SetGlobalRestServiceBaseHost(host string)
+
+	// GetService returns the FabricService for the channel name given as the parameter
+	GetService(serviceChannelName string) (FabricService, error)
 }
 
 type serviceRegistry struct {
@@ -48,13 +55,31 @@ func NewServiceRegistry(bus bus.EventBus) ServiceRegistry {
 		bus:      bus,
 		services: make(map[string]*fabricServiceWrapper),
 	}
+	// create a channel for service lifecycle manager
+	_ = bus.GetChannelManager().CreateChannel(LifecycleManagerChannelName)
+
 	// auto-register the restService
 	registry.RegisterService(&restService{}, restServiceChannel)
 	return registry
 }
 
+func (r *serviceRegistry) GetService(serviceChannelName string) (FabricService, error) {
+	if serviceWrapper, ok := r.services[serviceChannelName]; ok {
+		return serviceWrapper.service, nil
+	}
+	return nil, fmt.Errorf("fabric service not found at channel %s", serviceChannelName)
+}
+
 func (r *serviceRegistry) SetGlobalRestServiceBaseHost(host string) {
 	r.services[restServiceChannel].service.(*restService).setBaseHost(host)
+}
+
+func (r *serviceRegistry) GetAllServiceChannels() []string {
+	services := make([]string, 0)
+	for chanName, _ := range r.services {
+		services = append(services, chanName)
+	}
+	return services
 }
 
 func (r *serviceRegistry) RegisterService(service FabricService, serviceChannelName string) error {
@@ -76,6 +101,20 @@ func (r *serviceRegistry) RegisterService(service FabricService, serviceChannelN
 	}
 
 	r.services[serviceChannelName] = sw
+
+	// see if the service implements ServiceLifecycleHookEnabled interface and set up REST bridges as configured
+	var hooks ServiceLifecycleHookEnabled
+	lcm := GetServiceLifecycleManager(bus.GetBus(), r)
+	if hooks, err = lcm.GetServiceHooks(serviceChannelName); err != nil {
+		return err
+	}
+
+	// hand off registering REST bridges to Plank via bus messages
+	if err = bus.GetBus().SendResponseMessage(
+		LifecycleManagerChannelName, hooks.GetRESTBridgeConfig(), bus.GetBus().GetId()); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/service/service_registry.go
+++ b/service/service_registry.go
@@ -63,6 +63,8 @@ func NewServiceRegistry(bus bus.EventBus) ServiceRegistry {
 	return registry
 }
 
+// GetService returns the FabricService instance registered at the provided service channel name.
+// if no service is found at the service channel it returns an error.
 func (r *serviceRegistry) GetService(serviceChannelName string) (FabricService, error) {
 	if serviceWrapper, ok := r.services[serviceChannelName]; ok {
 		return serviceWrapper.service, nil

--- a/service/service_registry_test.go
+++ b/service/service_registry_test.go
@@ -36,7 +36,7 @@ func (fs *mockFabricService) HandleServiceRequest(request *model.Request, core F
 }
 
 type mockLifecycleHookEnabledService struct {
-    initChan chan struct{}
+    initChan chan bool
     core FabricServiceCore
     shutdown bool
 }
@@ -44,9 +44,9 @@ type mockLifecycleHookEnabledService struct {
 func (s *mockLifecycleHookEnabledService) HandleServiceRequest(request *model.Request, core FabricServiceCore) {
 }
 
-func (s *mockLifecycleHookEnabledService) OnServiceReady() chan struct{} {
-    s.initChan = make(chan struct{}, 1)
-    s.initChan <- struct{}{}
+func (s *mockLifecycleHookEnabledService) OnServiceReady() chan bool {
+    s.initChan = make(chan bool, 1)
+    s.initChan <- true
     return s.initChan
 }
 
@@ -207,8 +207,7 @@ func TestServiceRegistry_RegisterService_LifecycleHookEnabled(t *testing.T) {
     registry := newTestServiceRegistry()
     registry.RegisterService(svc, "another-test-channel")
 
-    <-svc.OnServiceReady()
-    assert.NotNil(t, svc.initChan)
+    assert.True(t, <-svc.OnServiceReady())
 
     svc.OnServerShutdown()
     assert.True(t, svc.shutdown)

--- a/service/service_registry_test.go
+++ b/service/service_registry_test.go
@@ -9,13 +9,18 @@ import (
     "github.com/stretchr/testify/assert"
     "github.com/vmware/transport-go/bus"
     "github.com/vmware/transport-go/model"
+    "net/http"
     "sync"
     "testing"
 )
 
 func newTestServiceRegistry() *serviceRegistry {
     eventBus := bus.NewEventBusInstance()
-    return NewServiceRegistry(eventBus).(*serviceRegistry)
+    return newServiceRegistry(eventBus).(*serviceRegistry)
+}
+
+func newTestServiceLifecycleManager(sr ServiceRegistry) ServiceLifecycleManager {
+    return newServiceLifecycleManager(sr)
 }
 
 type mockFabricService struct {
@@ -28,6 +33,43 @@ func (fs *mockFabricService) HandleServiceRequest(request *model.Request, core F
     fs.processedRequests = append(fs.processedRequests, request)
     fs.core = core
     fs.wg.Done()
+}
+
+type mockLifecycleHookEnabledService struct {
+    initChan chan struct{}
+    core FabricServiceCore
+    shutdown bool
+}
+
+func (s *mockLifecycleHookEnabledService) HandleServiceRequest(request *model.Request, core FabricServiceCore) {
+}
+
+func (s *mockLifecycleHookEnabledService) OnServiceReady() chan struct{} {
+    s.initChan = make(chan struct{}, 1)
+    s.initChan <- struct{}{}
+    return s.initChan
+}
+
+func (s *mockLifecycleHookEnabledService) OnServerShutdown() {
+    s.shutdown = true
+}
+
+func (s *mockLifecycleHookEnabledService) GetRESTBridgeConfig() []*RESTBridgeConfig {
+    return []*RESTBridgeConfig{
+        {
+            ServiceChannel:       "another-test-channel",
+            Uri:                  "/rest/test",
+            Method:               http.MethodGet,
+            AllowHead:            true,
+            AllowOptions:         true,
+            FabricRequestBuilder: func(w http.ResponseWriter, r *http.Request) model.Request {
+                return model.Request{
+                    Id: &uuid.UUID{},
+                    Payload: "test",
+                }
+            },
+        },
+    }
 }
 
 type mockInitializableService struct {
@@ -147,4 +189,30 @@ func TestServiceRegistry_SetGlobalRestServiceBaseHost(t *testing.T) {
     registry.SetGlobalRestServiceBaseHost("localhost:9999")
     assert.Equal(t, "localhost:9999",
             registry.services[restServiceChannel].service.(*restService).baseHost)
+}
+
+func TestServiceRegistry_GetAllServiceChannels(t *testing.T) {
+    registry := newTestServiceRegistry()
+    mockService := &mockFabricService{}
+
+    registry.RegisterService(mockService, "test-channel")
+    chans := registry.GetAllServiceChannels()
+
+    assert.Len(t, chans, 1)
+    assert.EqualValues(t, "test-channel", chans[0])
+}
+
+func TestServiceRegistry_RegisterService_LifecycleHookEnabled(t *testing.T) {
+    svc := &mockLifecycleHookEnabledService{}
+    registry := newTestServiceRegistry()
+    registry.RegisterService(svc, "another-test-channel")
+
+    <-svc.OnServiceReady()
+    assert.NotNil(t, svc.initChan)
+
+    svc.OnServerShutdown()
+    assert.True(t, svc.shutdown)
+
+    restBridgeConfig := svc.GetRESTBridgeConfig()
+    assert.NotNil(t, restBridgeConfig)
 }


### PR DESCRIPTION
This PR adds ServiceLifecycleManager and a service interface that would be implemented by Plank services for various lifecycle hooks for the Plank platform server. For now there are two hooks supported:

`OnServiceReady()` is called as part of the `RegisterService()` routine that registers the service. This function is to return a channel of `bool` type simply to signal to Plank platform that the service has finished initializing. A long running initialization needs to wrapped in another goroutine such as the following:

```go
func (s*SomeService) OnServiceReady() chan bool {
    doneC := make(chan bool)
    go func() {
        // some long running tasks
        doneC <- true
        close(doneC)
    }()
    return doneC
}
```

`OnServerShutdown()` is automatically called upon all registered services when the Plank server receives the kill/interruption signal. The server will enter the graceful shutdown process where it will wait for all services' `OnServerShutdown()` run and finish, unless any of them takes longer than the user specified graceful shutdown timeout in which case the Plank server process will be forcefully killed.