### PR TITLE
fix: websocket endpoint overwritten by SpaConfig

### DIFF
--- a/plank/config.json
+++ b/plank/config.json
@@ -2,7 +2,6 @@
   "debug": false,
   "no_banner": false,
   "root_dir": "./",
-  "static_dir": [],
   "spa_config": {
     "root_folder": "public/",
     "base_uri": "/",


### PR DESCRIPTION
When a Single Page Application is configured at the root URI `/` the Fabric WebSocket endpoint would be masked by it resulting the client not being able to connect to the Fabric. This PR fixes the bug by rearranging the order the SPA routes are configured.

Signed-off-by: Josh Kim <kjosh@vmware.com>