### PR TITLE
Added Reply-To support.

### DIFF
--- a/bridge/bridge_client.go
+++ b/bridge/bridge_client.go
@@ -4,256 +4,256 @@
 package bridge
 
 import (
-    "bufio"
-    "bytes"
-    "errors"
-    "fmt"
-    "github.com/go-stomp/stomp"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "github.com/gorilla/websocket"
-    "github.com/vmware/transport-go/model"
-    "log"
-    "net/url"
-    "os"
-    "strconv"
-    "sync"
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/go-stomp/stomp/v3"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/vmware/transport-go/model"
+	"log"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
 )
 
 // Bridge client encapsulates all subscriptions and io to and from brokers.
 type BridgeClient struct {
-    WSc              *websocket.Conn // WebSocket connection
-    TCPc             *stomp.Conn     // STOMP TCP Connection
-    ConnectedChan    chan bool
-    disconnectedChan chan bool
-    connected        bool
-    inboundChan      chan *frame.Frame
-    stompConnected   bool
-    Subscriptions    map[string]*BridgeClientSub
-    logger           *log.Logger
-    lock             sync.Mutex
-    sendLock         sync.Mutex
+	WSc              *websocket.Conn // WebSocket connection
+	TCPc             *stomp.Conn     // STOMP TCP Connection
+	ConnectedChan    chan bool
+	disconnectedChan chan bool
+	connected        bool
+	inboundChan      chan *frame.Frame
+	stompConnected   bool
+	Subscriptions    map[string]*BridgeClientSub
+	logger           *log.Logger
+	lock             sync.Mutex
+	sendLock         sync.Mutex
 }
 
 // Create a new WebSocket client.
 func NewBridgeWsClient(enableLogging bool) *BridgeClient {
-    return newBridgeWsClient(enableLogging)
+	return newBridgeWsClient(enableLogging)
 }
 
 func newBridgeWsClient(enableLogging bool) *BridgeClient {
-    var l *log.Logger = nil
-    if enableLogging {
-        l = log.New(os.Stderr, "WebSocket Client: ", 2)
-    }
-    return &BridgeClient{
-        WSc:              nil,
-        TCPc:             nil,
-        stompConnected:   false,
-        connected:        false,
-        logger:           l,
-        lock:             sync.Mutex{},
-        sendLock:         sync.Mutex{},
-        Subscriptions:    make(map[string]*BridgeClientSub),
-        ConnectedChan:    make(chan bool),
-        disconnectedChan: make(chan bool),
-        inboundChan:      make(chan *frame.Frame)}
+	var l *log.Logger = nil
+	if enableLogging {
+		l = log.New(os.Stderr, "WebSocket Client: ", 2)
+	}
+	return &BridgeClient{
+		WSc:              nil,
+		TCPc:             nil,
+		stompConnected:   false,
+		connected:        false,
+		logger:           l,
+		lock:             sync.Mutex{},
+		sendLock:         sync.Mutex{},
+		Subscriptions:    make(map[string]*BridgeClientSub),
+		ConnectedChan:    make(chan bool),
+		disconnectedChan: make(chan bool),
+		inboundChan:      make(chan *frame.Frame)}
 }
 
 // Connect to broker endpoint.
 func (ws *BridgeClient) Connect(url *url.URL, config *BrokerConnectorConfig) error {
-    ws.lock.Lock()
-    defer ws.lock.Unlock()
-    if ws.logger != nil {
-        ws.logger.Printf("connecting to fabric endpoint over %s", url.String())
-    }
+	ws.lock.Lock()
+	defer ws.lock.Unlock()
+	if ws.logger != nil {
+		ws.logger.Printf("connecting to fabric endpoint over %s", url.String())
+	}
 
-    // set TLS config if broker connector config demands that TLS be used
-    dialer := websocket.DefaultDialer
-    if config.WebSocketConfig.UseTLS {
-        if err := config.WebSocketConfig.LoadX509KeyPairFromFiles(
-            config.WebSocketConfig.CertFile,
-            config.WebSocketConfig.KeyFile); err != nil {
-            return err
-        }
-        dialer.TLSClientConfig = config.WebSocketConfig.TLSConfig
-    }
+	// set TLS config if broker connector config demands that TLS be used
+	dialer := websocket.DefaultDialer
+	if config.WebSocketConfig.UseTLS {
+		if err := config.WebSocketConfig.LoadX509KeyPairFromFiles(
+			config.WebSocketConfig.CertFile,
+			config.WebSocketConfig.KeyFile); err != nil {
+			return err
+		}
+		dialer.TLSClientConfig = config.WebSocketConfig.TLSConfig
+	}
 
-    c, _, err := dialer.Dial(url.String(), config.HttpHeader)
-    if err != nil {
-        return err
-    }
-    ws.WSc = c
+	c, _, err := dialer.Dial(url.String(), config.HttpHeader)
+	if err != nil {
+		return err
+	}
+	ws.WSc = c
 
-    // handle incoming STOMP frames.
-    go ws.handleIncomingSTOMPFrames()
+	// handle incoming STOMP frames.
+	go ws.handleIncomingSTOMPFrames()
 
-    // go listen to the websocket
-    go ws.listenSocket()
+	// go listen to the websocket
+	go ws.listenSocket()
 
-    stompHeaders := []string{
-        frame.AcceptVersion,
-        string(stomp.V12),
-        frame.Login,
-        config.Username,
-        frame.Passcode,
-        config.Password,
-        frame.HeartBeat,
-        fmt.Sprintf("%d,%d", config.HeartBeatOut.Milliseconds(), config.HeartBeatIn.Milliseconds())}
-    for key, value := range config.STOMPHeader {
-        stompHeaders = append(stompHeaders, key, value)
-    }
+	stompHeaders := []string{
+		frame.AcceptVersion,
+		string(stomp.V12),
+		frame.Login,
+		config.Username,
+		frame.Passcode,
+		config.Password,
+		frame.HeartBeat,
+		fmt.Sprintf("%d,%d", config.HeartBeatOut.Milliseconds(), config.HeartBeatIn.Milliseconds())}
+	for key, value := range config.STOMPHeader {
+		stompHeaders = append(stompHeaders, key, value)
+	}
 
-    // send connect frame.
-    ws.SendFrame(frame.New(frame.CONNECT, stompHeaders...))
+	// send connect frame.
+	ws.SendFrame(frame.New(frame.CONNECT, stompHeaders...))
 
-    // wait to be connected
-    <-ws.ConnectedChan
-    return nil
+	// wait to be connected
+	<-ws.ConnectedChan
+	return nil
 }
 
 // Disconnect from broker endpoint
 func (ws *BridgeClient) Disconnect() error {
-    if ws.WSc != nil {
-        defer ws.WSc.Close()
-        ws.disconnectedChan <- true
-    } else {
-        return fmt.Errorf("cannot disconnect, no connection defined")
-    }
-    return nil
+	if ws.WSc != nil {
+		defer ws.WSc.Close()
+		ws.disconnectedChan <- true
+	} else {
+		return fmt.Errorf("cannot disconnect, no connection defined")
+	}
+	return nil
 }
 
 // Subscribe to destination
 func (ws *BridgeClient) Subscribe(destination string) *BridgeClientSub {
-    ws.lock.Lock()
-    defer ws.lock.Unlock()
-    id := uuid.New()
-    s := &BridgeClientSub{
-        C:           make(chan *model.Message),
-        Id:          &id,
-        Client:      ws,
-        Destination: destination,
-        subscribed:  true}
+	ws.lock.Lock()
+	defer ws.lock.Unlock()
+	id := uuid.New()
+	s := &BridgeClientSub{
+		C:           make(chan *model.Message),
+		Id:          &id,
+		Client:      ws,
+		Destination: destination,
+		subscribed:  true}
 
-    ws.Subscriptions[destination] = s
+	ws.Subscriptions[destination] = s
 
-    // create subscription frame.
-    subscribeFrame := frame.New(frame.SUBSCRIBE,
-        frame.Id, id.String(),
-        frame.Destination, destination,
-        frame.Ack, stomp.AckAuto.String())
+	// create subscription frame.
+	subscribeFrame := frame.New(frame.SUBSCRIBE,
+		frame.Id, id.String(),
+		frame.Destination, destination,
+		frame.Ack, stomp.AckAuto.String())
 
-    // send subscription frame.
-    ws.SendFrame(subscribeFrame)
-    return s
+	// send subscription frame.
+	ws.SendFrame(subscribeFrame)
+	return s
 }
 
 // send a payload to a destination
 func (ws *BridgeClient) Send(destination, contentType string, payload []byte, opts ...func(fr *frame.Frame) error) {
-    ws.lock.Lock()
-    defer ws.lock.Unlock()
+	ws.lock.Lock()
+	defer ws.lock.Unlock()
 
-    // create send frame.
-    sendFrame := frame.New(frame.SEND,
-        frame.Destination, destination,
-        frame.ContentLength, strconv.Itoa(len(payload)),
-        frame.ContentType, contentType)
+	// create send frame.
+	sendFrame := frame.New(frame.SEND,
+		frame.Destination, destination,
+		frame.ContentLength, strconv.Itoa(len(payload)),
+		frame.ContentType, contentType)
 
-    // apply extra frame options such as adding extra headers
-    for _, frameOpt := range opts {
-        _ = frameOpt(sendFrame)
-    }
-    // add payload
-    sendFrame.Body = payload
+	// apply extra frame options such as adding extra headers
+	for _, frameOpt := range opts {
+		_ = frameOpt(sendFrame)
+	}
+	// add payload
+	sendFrame.Body = payload
 
-    // send frame
-    go ws.SendFrame(sendFrame)
+	// send frame
+	go ws.SendFrame(sendFrame)
 
 }
 
 // send a STOMP frame down the WebSocket
 func (ws *BridgeClient) SendFrame(f *frame.Frame) {
-    ws.sendLock.Lock()
-    defer ws.sendLock.Unlock()
-    var b bytes.Buffer
-    br := bufio.NewWriter(&b)
-    sw := frame.NewWriter(br)
+	ws.sendLock.Lock()
+	defer ws.sendLock.Unlock()
+	var b bytes.Buffer
+	br := bufio.NewWriter(&b)
+	sw := frame.NewWriter(br)
 
-    // write frame to buffer
-    sw.Write(f)
-    w, _ := ws.WSc.NextWriter(websocket.TextMessage)
-    defer w.Close()
+	// write frame to buffer
+	sw.Write(f)
+	w, _ := ws.WSc.NextWriter(websocket.TextMessage)
+	defer w.Close()
 
-    w.Write(b.Bytes())
+	w.Write(b.Bytes())
 
 }
 
 func (ws *BridgeClient) listenSocket() {
-    for {
-        // read each incoming message from websocket
-        _, p, err := ws.WSc.ReadMessage()
-        b := bytes.NewReader(p)
-        sr := frame.NewReader(b)
-        f, _ := sr.Read()
+	for {
+		// read each incoming message from websocket
+		_, p, err := ws.WSc.ReadMessage()
+		b := bytes.NewReader(p)
+		sr := frame.NewReader(b)
+		f, _ := sr.Read()
 
-        if err != nil {
-            break // socket can't be read anymore, exit.
-        }
-        if f != nil {
-            ws.inboundChan <- f
-        }
-    }
+		if err != nil {
+			break // socket can't be read anymore, exit.
+		}
+		if f != nil {
+			ws.inboundChan <- f
+		}
+	}
 }
 
 func (ws *BridgeClient) handleIncomingSTOMPFrames() {
-    for {
-        select {
-        case <-ws.disconnectedChan:
-            return
-        case f := <-ws.inboundChan:
-            switch f.Command {
-            case frame.CONNECTED:
-                if ws.logger != nil {
-                    ws.logger.Printf("STOMP Client connected")
-                }
-                ws.stompConnected = true
-                ws.connected = true
-                ws.ConnectedChan <- true
+	for {
+		select {
+		case <-ws.disconnectedChan:
+			return
+		case f := <-ws.inboundChan:
+			switch f.Command {
+			case frame.CONNECTED:
+				if ws.logger != nil {
+					ws.logger.Printf("STOMP Client connected")
+				}
+				ws.stompConnected = true
+				ws.connected = true
+				ws.ConnectedChan <- true
 
-            case frame.MESSAGE:
-                for _, sub := range ws.Subscriptions {
-                    if sub.Destination == f.Header.Get(frame.Destination) {
-                        c := &model.MessageConfig{Payload: f.Body, Destination: sub.Destination}
-                        sub.lock.RLock()
-                        if sub.subscribed {
-                            ws.sendResponseSafe(sub.C, model.GenerateResponse(c))
-                        }
-                        sub.lock.RUnlock()
-                    }
-                }
+			case frame.MESSAGE:
+				for _, sub := range ws.Subscriptions {
+					if sub.Destination == f.Header.Get(frame.Destination) {
+						c := &model.MessageConfig{Payload: f.Body, Destination: sub.Destination}
+						sub.lock.RLock()
+						if sub.subscribed {
+							ws.sendResponseSafe(sub.C, model.GenerateResponse(c))
+						}
+						sub.lock.RUnlock()
+					}
+				}
 
-            case frame.ERROR:
-                if ws.logger != nil {
-                    ws.logger.Printf("STOMP ErrorDir received")
-                }
+			case frame.ERROR:
+				if ws.logger != nil {
+					ws.logger.Printf("STOMP ErrorDir received")
+				}
 
-                for _, sub := range ws.Subscriptions {
-                    if sub.Destination == f.Header.Get(frame.Destination) {
-                        c := &model.MessageConfig{Payload: f.Body, Err: errors.New("STOMP ErrorDir " + string(f.Body))}
-                        sub.E <- model.GenerateError(c)
-                    }
-                }
-            }
-        }
-    }
+				for _, sub := range ws.Subscriptions {
+					if sub.Destination == f.Header.Get(frame.Destination) {
+						c := &model.MessageConfig{Payload: f.Body, Err: errors.New("STOMP ErrorDir " + string(f.Body))}
+						sub.E <- model.GenerateError(c)
+					}
+				}
+			}
+		}
+	}
 }
 
 func (ws *BridgeClient) sendResponseSafe(C chan *model.Message, m *model.Message) {
-    defer func() {
-        if r := recover(); r != nil {
-            if ws.logger != nil {
-                ws.logger.Println("channel is closed, message undeliverable to closed channel.")
-            }
-        }
-    }()
-    C <- m
+	defer func() {
+		if r := recover(); r != nil {
+			if ws.logger != nil {
+				ws.logger.Println("channel is closed, message undeliverable to closed channel.")
+			}
+		}
+	}()
+	C <- m
 }

--- a/bridge/bridge_client_subscription.go
+++ b/bridge/bridge_client_subscription.go
@@ -4,31 +4,31 @@
 package bridge
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "github.com/vmware/transport-go/model"
-    "sync"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"github.com/vmware/transport-go/model"
+	"sync"
 )
 
 // BridgeClientSub is a client subscription that encapsulates message and error channels for a subscription
 type BridgeClientSub struct {
-    C           chan *model.Message // MESSAGE payloads
-    E           chan *model.Message // ERROR payloads.
-    Id          *uuid.UUID
-    Destination string
-    Client      *BridgeClient
-    subscribed  bool
-    lock        sync.RWMutex
+	C           chan *model.Message // MESSAGE payloads
+	E           chan *model.Message // ERROR payloads.
+	Id          *uuid.UUID
+	Destination string
+	Client      *BridgeClient
+	subscribed  bool
+	lock        sync.RWMutex
 }
 
 // Send an UNSUBSCRIBE frame for subscription destination.
 func (cs *BridgeClientSub) Unsubscribe() {
-    cs.lock.Lock()
-    cs.subscribed = false
-    cs.lock.Unlock()
-    unsubscribeFrame := frame.New(frame.UNSUBSCRIBE,
-        frame.Id, cs.Id.String(),
-        frame.Destination, cs.Destination)
+	cs.lock.Lock()
+	cs.subscribed = false
+	cs.lock.Unlock()
+	unsubscribeFrame := frame.New(frame.UNSUBSCRIBE,
+		frame.Id, cs.Id.String(),
+		frame.Destination, cs.Destination)
 
-    cs.Client.SendFrame(unsubscribeFrame)
+	cs.Client.SendFrame(unsubscribeFrame)
 }

--- a/bridge/bridge_client_test.go
+++ b/bridge/bridge_client_test.go
@@ -4,46 +4,46 @@
 package bridge
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "github.com/stretchr/testify/assert"
-    "github.com/vmware/transport-go/model"
-    "log"
-    "os"
-    "sync"
-    "testing"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/transport-go/model"
+	"log"
+	"os"
+	"sync"
+	"testing"
 )
 
 func TestBridgeClient_Disconnect(t *testing.T) {
 
-    bc := new(BridgeClient)
-    e := bc.Disconnect()
-    assert.NotNil(t, e)
+	bc := new(BridgeClient)
+	e := bc.Disconnect()
+	assert.NotNil(t, e)
 }
 
 func TestBridgeClient_handleCommands(t *testing.T) {
-    d := "rainbow-land"
-    bc := new(BridgeClient)
-    i := make(chan *frame.Frame, 1)
-    e := make(chan *model.Message, 1)
+	d := "rainbow-land"
+	bc := new(BridgeClient)
+	i := make(chan *frame.Frame, 1)
+	e := make(chan *model.Message, 1)
 
-    l := log.New(os.Stderr, "WebSocket Client: ", 2)
-    bc.logger = l
-    bc.inboundChan = i
-    bc.Subscriptions = make(map[string]*BridgeClientSub)
-    s := &BridgeClientSub{E: e, Destination: d}
-    bc.Subscriptions[d] = s
+	l := log.New(os.Stderr, "WebSocket Client: ", 2)
+	bc.logger = l
+	bc.inboundChan = i
+	bc.Subscriptions = make(map[string]*BridgeClientSub)
+	s := &BridgeClientSub{E: e, Destination: d}
+	bc.Subscriptions[d] = s
 
-    go bc.handleIncomingSTOMPFrames()
-    wg := sync.WaitGroup{}
+	go bc.handleIncomingSTOMPFrames()
+	wg := sync.WaitGroup{}
 
-    var sendError = func() {
-        f := frame.New(frame.ERROR, frame.Destination, d)
-        bc.inboundChan <- f
-        wg.Done()
-    }
-    wg.Add(1)
-    go sendError()
-    wg.Wait()
-    m := <- s.E
-    assert.Error(t, m.Error)
+	var sendError = func() {
+		f := frame.New(frame.ERROR, frame.Destination, d)
+		bc.inboundChan <- f
+		wg.Done()
+	}
+	wg.Add(1)
+	go sendError()
+	wg.Wait()
+	m := <-s.E
+	assert.Error(t, m.Error)
 }

--- a/bridge/broker_connector.go
+++ b/bridge/broker_connector.go
@@ -4,11 +4,11 @@
 package bridge
 
 import (
-    "fmt"
-    "github.com/go-stomp/stomp"
-    "github.com/google/uuid"
-    "net/url"
-    "sync"
+	"fmt"
+	"github.com/go-stomp/stomp/v3"
+	"github.com/google/uuid"
+	"net/url"
+	"sync"
 )
 
 // BrokerConnector is used to connect to a message broker over TCP or WebSocket.
@@ -99,21 +99,21 @@ func (bc *brokerConnector) connectWs(config *BrokerConnectorConfig, enableLoggin
 		wsScheme += "s"
 	}
 
-    u := url.URL{Scheme: wsScheme, Host: config.ServerAddr, Path: config.WebSocketConfig.WSPath}
-    c := NewBridgeWsClient(enableLogging)
-    err := c.Connect(&u, config)
-    if err != nil {
-        return nil, fmt.Errorf("cannot connect to host '%s' via path '%s', stopping", config.ServerAddr, config.WebSocketConfig.WSPath)
-    }
-    id := uuid.New()
-    bcConn := &connection{
-        id:             &id,
-        wsConn:         c,
-        subscriptions:  make(map[string]Subscription),
-        useWs:          true,
-        connLock:       sync.Mutex{},
-        disconnectChan: make(chan bool)}
-    bc.c = bcConn
-    bc.connected = true
-    return bcConn, nil
+	u := url.URL{Scheme: wsScheme, Host: config.ServerAddr, Path: config.WebSocketConfig.WSPath}
+	c := NewBridgeWsClient(enableLogging)
+	err := c.Connect(&u, config)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to host '%s' via path '%s', stopping", config.ServerAddr, config.WebSocketConfig.WSPath)
+	}
+	id := uuid.New()
+	bcConn := &connection{
+		id:             &id,
+		wsConn:         c,
+		subscriptions:  make(map[string]Subscription),
+		useWs:          true,
+		connLock:       sync.Mutex{},
+		disconnectChan: make(chan bool)}
+	bc.c = bcConn
+	bc.connected = true
+	return bcConn, nil
 }

--- a/bridge/broker_connector_tls_test.go
+++ b/bridge/broker_connector_tls_test.go
@@ -4,17 +4,17 @@
 package bridge
 
 import (
-    "crypto/tls"
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/go-stomp/stomp/server"
-    "github.com/stretchr/testify/assert"
-    "log"
-    "net"
-    "net/http"
-    "net/http/httptest"
-    "net/url"
-    "testing"
+	"crypto/tls"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/go-stomp/stomp/v3/server"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
 )
 
 var webSocketURLChanTLS = make(chan string)
@@ -22,139 +22,138 @@ var websocketURLTLS string
 
 //var srv Server
 var testTLS = &tls.Config{
-    InsecureSkipVerify: true,
-    MinVersion:         tls.VersionTLS12,
-    CipherSuites: []uint16{
-        tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-        tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-        tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-    },
+	InsecureSkipVerify: true,
+	MinVersion:         tls.VersionTLS12,
+	CipherSuites: []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	},
 }
 
 func runWebSocketEndPointTLS() {
-    s := httptest.NewUnstartedServer(http.HandlerFunc(websocketHandler))
-    s.TLS = testTLS
-    s.StartTLS()
-    log.Println("WebSocket listening on", s.Listener.Addr().Network(), s.Listener.Addr().String(), "(TLS)")
-    httpServer = s
-    webSocketURLChanTLS <- s.URL
+	s := httptest.NewUnstartedServer(http.HandlerFunc(websocketHandler))
+	s.TLS = testTLS
+	s.StartTLS()
+	log.Println("WebSocket listening on", s.Listener.Addr().Network(), s.Listener.Addr().String(), "(TLS)")
+	httpServer = s
+	webSocketURLChanTLS <- s.URL
 }
 
 func runStompBrokerTLS() {
-    l, err := net.Listen("tcp", ":51582")
-    if err != nil {
-        log.Fatalf("failed to listen: %s", err.Error())
-    }
-    defer func() { l.Close() }()
+	l, err := net.Listen("tcp", ":51582")
+	if err != nil {
+		log.Fatalf("failed to listen: %s", err.Error())
+	}
+	defer func() { l.Close() }()
 
-    log.Println("TCP listening on", l.Addr().Network(), l.Addr().String(), "(TLS)")
-    server.Serve(l)
-    tcpServer = l
+	log.Println("TCP listening on", l.Addr().Network(), l.Addr().String(), "(TLS)")
+	server.Serve(l)
+	tcpServer = l
 }
 
 func init() {
-    go runStompBrokerTLS()
-    go runWebSocketEndPointTLS()
+	go runStompBrokerTLS()
+	go runWebSocketEndPointTLS()
 
-    websocketURLTLS = <-webSocketURLChanTLS
+	websocketURLTLS = <-webSocketURLChanTLS
 }
 
 func TestBrokerConnector_ConnectBroker_Invalid_TLS_Cert(t *testing.T) {
-    url, _ := url.Parse(websocketURLTLS)
-    host, port, _ := net.SplitHostPort(url.Host)
-    testHost := host + ":" + port
+	url, _ := url.Parse(websocketURLTLS)
+	host, port, _ := net.SplitHostPort(url.Host)
+	testHost := host + ":" + port
 
-    brokerConfig := &BrokerConnectorConfig{
-        Username: "guest",
-        Password: "guest",
-        UseWS: true,
-        WebSocketConfig: &WebSocketConfig{
-            WSPath:    "/fabric",
-            UseTLS:    true,
-            TLSConfig: testTLS,
-            CertFile:  "nothing",
-            KeyFile:   "nothing",
-        },
-        ServerAddr: testHost,
-    }
-    bc := NewBrokerConnector()
-    _, err := bc.Connect(brokerConfig, true)
+	brokerConfig := &BrokerConnectorConfig{
+		Username: "guest",
+		Password: "guest",
+		UseWS:    true,
+		WebSocketConfig: &WebSocketConfig{
+			WSPath:    "/fabric",
+			UseTLS:    true,
+			TLSConfig: testTLS,
+			CertFile:  "nothing",
+			KeyFile:   "nothing",
+		},
+		ServerAddr: testHost,
+	}
+	bc := NewBrokerConnector()
+	_, err := bc.Connect(brokerConfig, true)
 
-    assert.NotNil(t, err)
+	assert.NotNil(t, err)
 }
 
 func TestBrokerConnector_ConnectBroker_TLS(t *testing.T) {
-    url, _ := url.Parse(websocketURLTLS)
-    host, port, _ := net.SplitHostPort(url.Host)
-    testHost := host + ":" + port
+	url, _ := url.Parse(websocketURLTLS)
+	host, port, _ := net.SplitHostPort(url.Host)
+	testHost := host + ":" + port
 
-    tt := []struct {
-        test   string
-        config *BrokerConnectorConfig
-    }{
-        {
-            "Connect via websocket with TLS",
-            &BrokerConnectorConfig{
-                Username: "guest",
-                Password: "guest",
-                WebSocketConfig: &WebSocketConfig{
-                    WSPath: "/",
-                    UseTLS: true,
-                    CertFile: "test_server.crt",
-                    KeyFile: "test_server.key",
-                    TLSConfig: testTLS,
-                },
-                UseWS: true,
-                STOMPHeader: map[string]string{
-                    "access-token": "test",
-                },
-                ServerAddr: testHost},
-        },
-    }
+	tt := []struct {
+		test   string
+		config *BrokerConnectorConfig
+	}{
+		{
+			"Connect via websocket with TLS",
+			&BrokerConnectorConfig{
+				Username: "guest",
+				Password: "guest",
+				WebSocketConfig: &WebSocketConfig{
+					WSPath:    "/",
+					UseTLS:    true,
+					CertFile:  "test_server.crt",
+					KeyFile:   "test_server.key",
+					TLSConfig: testTLS,
+				},
+				UseWS: true,
+				STOMPHeader: map[string]string{
+					"access-token": "test",
+				},
+				ServerAddr: testHost},
+		},
+	}
 
-    for _, tc := range tt {
-        t.Run(tc.test, func(t *testing.T) {
+	for _, tc := range tt {
+		t.Run(tc.test, func(t *testing.T) {
 
-            // connect
-            bc := NewBrokerConnector()
-            c, err := bc.Connect(tc.config, true)
+			// connect
+			bc := NewBrokerConnector()
+			c, err := bc.Connect(tc.config, true)
 
-            if err != nil {
-                fmt.Printf("unable to connect, error: %e", err)
-            }
+			if err != nil {
+				fmt.Printf("unable to connect, error: %e", err)
+			}
 
-            assert.NotNil(t, c)
-            assert.Nil(t, err)
-            if tc.config.UseWS {
-                assert.NotNil(t, c.(*connection).wsConn)
-            }
-            if !tc.config.UseWS {
-                assert.NotNil(t, c.(*connection).conn)
-            }
+			assert.NotNil(t, c)
+			assert.Nil(t, err)
+			if tc.config.UseWS {
+				assert.NotNil(t, c.(*connection).wsConn)
+			}
+			if !tc.config.UseWS {
+				assert.NotNil(t, c.(*connection).conn)
+			}
 
-            m, _ := c.Subscribe("/topic/test-topic")
-            go func() {
-                err = c.SendJSONMessage("/topic/test-topic", []byte("{}"), func(frame *frame.Frame) error {
-                    frame.Header.Set("access-token", "test")
-                    return nil
-                })
-                assert.Nil(t, err)
-            }()
-            msg := <-m.GetMsgChannel()
-            b := msg.Payload.([]byte)
-            assert.EqualValues(t, "happy baby melody!", string(b))
+			m, _ := c.Subscribe("/topic/test-topic")
+			go func() {
+				err = c.SendJSONMessage("/topic/test-topic", []byte("{}"), func(frame *frame.Frame) error {
+					frame.Header.Set("access-token", "test")
+					return nil
+				})
+				assert.Nil(t, err)
+			}()
+			msg := <-m.GetMsgChannel()
+			b := msg.Payload.([]byte)
+			assert.EqualValues(t, "happy baby melody!", string(b))
 
-
-            // disconnect
-            err = c.Disconnect()
-            assert.Nil(t, err)
-            if tc.config.UseWS {
-                assert.Nil(t, c.(*connection).wsConn)
-            }
-            if !tc.config.UseWS {
-                assert.Nil(t, c.(*connection).conn)
-            }
-        })
-    }
+			// disconnect
+			err = c.Disconnect()
+			assert.Nil(t, err)
+			if tc.config.UseWS {
+				assert.Nil(t, c.(*connection).wsConn)
+			}
+			if !tc.config.UseWS {
+				assert.Nil(t, c.(*connection).conn)
+			}
+		})
+	}
 }

--- a/bridge/connection.go
+++ b/bridge/connection.go
@@ -4,156 +4,221 @@
 package bridge
 
 import (
-    "fmt"
-    "github.com/go-stomp/stomp"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "github.com/vmware/transport-go/model"
-    "log"
-    "sync"
+	"fmt"
+	"github.com/go-stomp/stomp/v3"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"github.com/vmware/transport-go/model"
+	"log"
+	"sync"
 )
 
 type Connection interface {
-    GetId() *uuid.UUID
-    Subscribe(destination string) (Subscription, error)
-    Disconnect() (err error)
-    SendJSONMessage(destination string, payload []byte, opts ...func(*frame.Frame) error) error
-    SendMessage(destination, contentType string, payload []byte, opts ...func(*frame.Frame) error) error
+	GetId() *uuid.UUID
+	Subscribe(destination string) (Subscription, error)
+	SubscribeReplyDestination(destination string) (Subscription, error)
+	Disconnect() (err error)
+	SendJSONMessage(destination string, payload []byte, opts ...func(*frame.Frame) error) error
+	SendMessage(destination, contentType string, payload []byte, opts ...func(*frame.Frame) error) error
+	SendMessageWithReplyDestination(destination, replyDestination, contentType string, payload []byte, opts ...func(*frame.Frame) error) error
 }
 
 // Connection represents a Connection to a message broker.
 type connection struct {
-    id             *uuid.UUID
-    useWs          bool
-    conn           *stomp.Conn
-    wsConn         *BridgeClient
-    disconnectChan chan bool
-    subscriptions  map[string]Subscription
-    connLock       sync.Mutex
+	id             *uuid.UUID
+	useWs          bool
+	conn           *stomp.Conn
+	wsConn         *BridgeClient
+	disconnectChan chan bool
+	subscriptions  map[string]Subscription
+	connLock       sync.Mutex
 }
 
-func (c *connection) GetId() *uuid.UUID{
-    return c.id
+func (c *connection) GetId() *uuid.UUID {
+	return c.id
 }
 
 // Subscribe to a destination, only one subscription can exist for a destination
 func (c *connection) Subscribe(destination string) (Subscription, error) {
-    // check if the subscription exists, if so, return it.
-    if c == nil {
-        return nil, fmt.Errorf("cannot subscribe to '%s', no connection to broker", destination)
-    }
+	// check if the subscription exists, if so, return it.
+	if c == nil {
+		return nil, fmt.Errorf("cannot subscribe to '%s', no connection to broker", destination)
+	}
 
-    c.connLock.Lock()
-    if sub, ok := c.subscriptions[destination]; ok {
-        c.connLock.Unlock()
-        return sub, nil
-    }
-    c.connLock.Unlock()
+	c.connLock.Lock()
+	if sub, ok := c.subscriptions[destination]; ok {
+		c.connLock.Unlock()
+		return sub, nil
+	}
+	c.connLock.Unlock()
 
-    // use websocket, if not use stomp TCP.
-    if c.useWs {
-        return c.subscribeWs(destination)
-    }
+	// use websocket, if not use stomp TCP.
+	if c.useWs {
+		return c.subscribeWs(destination)
+	}
 
-    return c.subscribeTCP(destination)
+	return c.subscribeTCP(destination)
+}
+
+// SubscribeReplyDestination subscribe to a reply destination (this will create an internal subscription to the
+// destination, but won't actually send the request over the wire to the broker. This is because when using temp
+// queues, the destinations are dynamic. The raw socket is send responses that are to a destination that
+// does not actually exist when using reply-to so this will allow that imaginary destination to operate.
+func (c *connection) SubscribeReplyDestination(destination string) (Subscription, error) {
+	// check if the subscription exists, if so, return it.
+	if c == nil {
+		return nil, fmt.Errorf("cannot subscribe to '%s', no connection to broker", destination)
+	}
+
+	c.connLock.Lock()
+	if sub, ok := c.subscriptions[destination]; ok {
+		c.connLock.Unlock()
+		return sub, nil
+	}
+	c.connLock.Unlock()
+
+	// use websocket, if not use stomp TCP.
+	if c.useWs {
+		return c.subscribeWs(destination)
+	}
+
+	return c.subscribeTCPUsingReplyDestination(destination)
 }
 
 // Disconnect from broker, will close all channels
 func (c *connection) Disconnect() (err error) {
-    if c == nil {
-        return fmt.Errorf("cannot disconnect, not connected")
-    }
-    if c.useWs {
-        if c.wsConn != nil && c.wsConn.connected {
-            defer c.cleanUpConnection()
-            err = c.wsConn.Disconnect()
-        }
-    } else {
-        if c.conn != nil {
-            defer c.cleanUpConnection()
-            err = c.conn.Disconnect()
-        }
-    }
-    return err
+	if c == nil {
+		return fmt.Errorf("cannot disconnect, not connected")
+	}
+	if c.useWs {
+		if c.wsConn != nil && c.wsConn.connected {
+			defer c.cleanUpConnection()
+			err = c.wsConn.Disconnect()
+		}
+	} else {
+		if c.conn != nil {
+			defer c.cleanUpConnection()
+			err = c.conn.Disconnect()
+		}
+	}
+	return err
 }
 
 func (c *connection) cleanUpConnection() {
-    if c.conn != nil {
-        c.conn = nil
-    }
-    if c.wsConn != nil {
-        c.wsConn = nil
-    }
+	if c.conn != nil {
+		c.conn = nil
+	}
+	if c.wsConn != nil {
+		c.wsConn = nil
+	}
 }
 
 func (c *connection) subscribeWs(destination string) (Subscription, error) {
-    c.connLock.Lock()
-    defer c.connLock.Unlock()
-    if c.wsConn != nil {
-        wsSub := c.wsConn.Subscribe(destination)
-        sub := &subscription{wsStompSub: wsSub, id: wsSub.Id, c: wsSub.C, destination: destination}
-        c.subscriptions[destination] = sub
-        return sub, nil
-    }
-    return nil, fmt.Errorf("cannot subscribe, websocket not connected / established")
+	c.connLock.Lock()
+	defer c.connLock.Unlock()
+	if c.wsConn != nil {
+		wsSub := c.wsConn.Subscribe(destination)
+		sub := &subscription{wsStompSub: wsSub, id: wsSub.Id, c: wsSub.C, destination: destination}
+		c.subscriptions[destination] = sub
+		return sub, nil
+	}
+	return nil, fmt.Errorf("cannot subscribe, websocket not connected / established")
 }
 
 func (c *connection) subscribeTCP(destination string) (Subscription, error) {
-    c.connLock.Lock()
-    defer c.connLock.Unlock()
-    if c.conn != nil {
-        sub, _ := c.conn.Subscribe(destination, stomp.AckAuto)
-        id := uuid.New()
-        destChan := make(chan *model.Message)
-        go c.listenTCPFrames(sub.C, destChan)
-        bcSub := &subscription{stompTCPSub: sub, id: &id, c: destChan}
-        c.subscriptions[destination] = bcSub
-        return bcSub, nil
-    }
-    return nil, fmt.Errorf("no STOMP TCP connection established")
+	c.connLock.Lock()
+	defer c.connLock.Unlock()
+	if c.conn != nil {
+		sub, _ := c.conn.Subscribe(destination, stomp.AckAuto)
+		id := uuid.New()
+		destChan := make(chan *model.Message)
+		go c.listenTCPFrames(sub.C, destChan)
+		bcSub := &subscription{stompTCPSub: sub, id: &id, c: destChan}
+		c.subscriptions[destination] = bcSub
+		return bcSub, nil
+	}
+	return nil, fmt.Errorf("no STOMP TCP connection established")
+}
+
+func (c *connection) subscribeTCPUsingReplyDestination(destination string) (Subscription, error) {
+	c.connLock.Lock()
+	defer c.connLock.Unlock()
+	if c.conn != nil {
+
+		var reply = func(f *frame.Frame) error {
+			f.Header.Add("reply-to", destination)
+			return nil
+		}
+
+		sub, _ := c.conn.Subscribe(destination, stomp.AckAuto, reply)
+		id := uuid.New()
+		destChan := make(chan *model.Message)
+		go c.listenTCPFrames(sub.C, destChan)
+		bcSub := &subscription{stompTCPSub: sub, id: &id, c: destChan}
+		c.subscriptions[destination] = bcSub
+		return bcSub, nil
+	}
+	return nil, fmt.Errorf("no STOMP TCP connection established")
 }
 
 func (c *connection) listenTCPFrames(src chan *stomp.Message, dst chan *model.Message) {
-    defer func() {
-        if r := recover(); r != nil {
-            log.Println("subscription is closed, message undeliverable to closed channel.")
-        }
-    }()
-    for {
-        f := <-src
-        var body []byte
-        var dest string
-        if f != nil && f.Body != nil {
-            body = f.Body
-        }
-        if f!= nil && len(f.Destination) > 0  {
-            dest = f.Destination
-        }
-        if f != nil {
-            cf := &model.MessageConfig{Payload: body, Destination: dest}
-            m := model.GenerateResponse(cf)
-            dst <- m
-        }
-    }
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("subscription is closed, message undeliverable to closed channel.")
+		}
+	}()
+	for {
+		f := <-src
+		var body []byte
+		var dest string
+		if f != nil && f.Body != nil {
+			body = f.Body
+		}
+		if f != nil && len(f.Destination) > 0 {
+			dest = f.Destination
+		}
+		if f != nil {
+			cf := &model.MessageConfig{Payload: body, Destination: dest}
+
+			// transfer over known non-standard, but important frame headers if they are set
+			if replyTo, ok := f.Header.Contains("reply-to"); ok { // used by rabbitmq for temp queues
+				cf.Headers = []model.MessageHeader{{Label: "reply-to", Value: replyTo}}
+			}
+
+			m := model.GenerateResponse(cf)
+			dst <- m
+		}
+	}
 }
 
 // SendJSONMessage sends a []byte payload carrying JSON data to a destination.
 func (c *connection) SendJSONMessage(destination string, payload []byte, opts ...func(*frame.Frame) error) error {
-    return c.SendMessage(destination, "application/json", payload, opts...)
+	return c.SendMessage(destination, "application/json", payload, opts...)
 }
 
-// Send a []byte payload to a destination.
+// SendMessageWithReplyDestination is the same as SendMessage, but adds in a reply-to header automatically.
+// This is generally used in conjunction with SubscribeReplyDestination
+func (c *connection) SendMessageWithReplyDestination(destination string, replyDestination, contentType string, payload []byte, opts ...func(*frame.Frame) error) error {
+	var headerReplyTo = func(f *frame.Frame) error {
+		f.Header.Add("reply-to", replyDestination)
+		return nil
+	}
+	opts = append(opts, headerReplyTo)
+	return c.SendMessage(destination, contentType, payload, opts...)
+}
+
+// SendMessage will send a []byte payload to a destination.
 func (c *connection) SendMessage(destination string, contentType string, payload []byte, opts ...func(*frame.Frame) error) error {
-    c.connLock.Lock()
-    defer c.connLock.Unlock()
-    if c != nil && !c.useWs && c.conn != nil {
-        c.conn.Send(destination, contentType, payload, opts...)
-        return nil
-    }
-    if c != nil && c.useWs && c.wsConn != nil {
-        c.wsConn.Send(destination, contentType, payload, opts...)
-        return nil
-    }
-    return fmt.Errorf("cannot send message, no connection")
+	c.connLock.Lock()
+	defer c.connLock.Unlock()
+	if c != nil && !c.useWs && c.conn != nil {
+		c.conn.Send(destination, contentType, payload, opts...)
+		return nil
+	}
+	if c != nil && c.useWs && c.wsConn != nil {
+		c.wsConn.Send(destination, contentType, payload, opts...)
+		return nil
+	}
+	return fmt.Errorf("cannot send message, no connection")
 
 }

--- a/bridge/subscription.go
+++ b/bridge/subscription.go
@@ -4,55 +4,55 @@
 package bridge
 
 import (
-    "fmt"
-    "github.com/go-stomp/stomp"
-    "github.com/google/uuid"
-    "github.com/vmware/transport-go/model"
+	"fmt"
+	"github.com/go-stomp/stomp/v3"
+	"github.com/google/uuid"
+	"github.com/vmware/transport-go/model"
 )
 
 type Subscription interface {
-    GetId() *uuid.UUID
-    GetMsgChannel() chan *model.Message
-    GetDestination() string
-    Unsubscribe() error
+	GetId() *uuid.UUID
+	GetMsgChannel() chan *model.Message
+	GetDestination() string
+	Unsubscribe() error
 }
 
 // Subscription represents a subscription to a broker destination.
 type subscription struct {
-    c           chan *model.Message // listen to this for incoming messages
-    id          *uuid.UUID
-    destination string              // Destination of where this message was sent.
-    stompTCPSub *stomp.Subscription
-    wsStompSub  *BridgeClientSub
+	c           chan *model.Message // listen to this for incoming messages
+	id          *uuid.UUID
+	destination string // Destination of where this message was sent.
+	stompTCPSub *stomp.Subscription
+	wsStompSub  *BridgeClientSub
 }
 
 func (s *subscription) GetId() *uuid.UUID {
-    return s.id
+	return s.id
 }
 
 func (s *subscription) GetMsgChannel() chan *model.Message {
-    return s.c
+	return s.c
 }
 
 func (s *subscription) GetDestination() string {
-    return s.destination
+	return s.destination
 }
 
 // Unsubscribe from destination. All channels will be closed.
 func (s *subscription) Unsubscribe() error {
 
-    // if we're using TCP
-    if s.stompTCPSub != nil {
-        go s.stompTCPSub.Unsubscribe() // local broker hangs, so lets make sure it is non blocking.
-        close(s.c)
-        return nil
-    }
+	// if we're using TCP
+	if s.stompTCPSub != nil {
+		go s.stompTCPSub.Unsubscribe() // local broker hangs, so lets make sure it is non blocking.
+		close(s.c)
+		return nil
+	}
 
-    // if we're using Websockets.
-    if s.wsStompSub != nil {
-        s.wsStompSub.Unsubscribe()
-        close(s.c)
-        return nil
-    }
-    return fmt.Errorf("cannot unsubscribe from destination %s, no connection", s.destination)
+	// if we're using Websockets.
+	if s.wsStompSub != nil {
+		s.wsStompSub.Unsubscribe()
+		close(s.c)
+		return nil
+	}
+	return fmt.Errorf("cannot unsubscribe from destination %s, no connection", s.destination)
 }

--- a/bus/channel_test.go
+++ b/bus/channel_test.go
@@ -4,294 +4,300 @@
 package bus
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/mock"
-    "github.com/vmware/transport-go/bridge"
-    "github.com/vmware/transport-go/model"
-    "testing"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/vmware/transport-go/bridge"
+	"github.com/vmware/transport-go/model"
+	"testing"
 )
 
 var testChannelName string = "testing"
 
 func TestChannel_CheckChannelCreation(t *testing.T) {
 
-    channel := NewChannel(testChannelName)
-    assert.Empty(t, channel.eventHandlers)
+	channel := NewChannel(testChannelName)
+	assert.Empty(t, channel.eventHandlers)
 
 }
 
 func TestChannel_SubscribeHandler(t *testing.T) {
-    id := uuid.New()
-    channel := NewChannel(testChannelName)
-    handler := func(*model.Message) {}
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	id := uuid.New()
+	channel := NewChannel(testChannelName)
+	handler := func(*model.Message) {}
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
 
-    assert.Equal(t, 1, len(channel.eventHandlers))
+	assert.Equal(t, 1, len(channel.eventHandlers))
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
 
-    assert.Equal(t, 2, len(channel.eventHandlers))
+	assert.Equal(t, 2, len(channel.eventHandlers))
 }
 
 func TestChannel_HandlerCheck(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    id := uuid.New()
-    assert.False(t, channel.ContainsHandlers())
+	channel := NewChannel(testChannelName)
+	id := uuid.New()
+	assert.False(t, channel.ContainsHandlers())
 
-    handler := func(*model.Message) {}
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	handler := func(*model.Message) {}
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
 
-    assert.True(t, channel.ContainsHandlers())
+	assert.True(t, channel.ContainsHandlers())
 }
 
 func TestChannel_SendMessage(t *testing.T) {
-    id := uuid.New()
-    channel := NewChannel(testChannelName)
-    handler := func(message *model.Message) {
-        assert.Equal(t, message.Payload.(string), "pickled eggs")
-        assert.Equal(t, message.Channel, testChannelName)
-    }
+	id := uuid.New()
+	channel := NewChannel(testChannelName)
+	handler := func(message *model.Message) {
+		assert.Equal(t, message.Payload.(string), "pickled eggs")
+		assert.Equal(t, message.Channel, testChannelName)
+	}
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
 
-    var message = &model.Message{
-        Id:        &id,
-        Payload:   "pickled eggs",
-        Channel:   testChannelName,
-        Direction: model.RequestDir}
+	var message = &model.Message{
+		Id:        &id,
+		Payload:   "pickled eggs",
+		Channel:   testChannelName,
+		Direction: model.RequestDir}
 
-    channel.Send(message)
-    channel.wg.Wait()
+	channel.Send(message)
+	channel.wg.Wait()
 }
 
 func TestChannel_SendMessageRunOnceHasRun(t *testing.T) {
-    id := uuid.New()
-    channel := NewChannel(testChannelName)
-    count := 0
-    handler := func(message *model.Message) {
-        assert.Equal(t, message.Payload.(string), "pickled eggs")
-        assert.Equal(t, message.Channel, testChannelName)
-        count++
-    }
+	id := uuid.New()
+	channel := NewChannel(testChannelName)
+	count := 0
+	handler := func(message *model.Message) {
+		assert.Equal(t, message.Payload.(string), "pickled eggs")
+		assert.Equal(t, message.Channel, testChannelName)
+		count++
+	}
 
-    h := &channelEventHandler{callBackFunction: handler, runOnce: true, uuid: &id}
-    channel.subscribeHandler(h)
+	h := &channelEventHandler{callBackFunction: handler, runOnce: true, uuid: &id}
+	channel.subscribeHandler(h)
 
-    var message = &model.Message{
-        Id:        &id,
-        Payload:   "pickled eggs",
-        Channel:   testChannelName,
-        Direction: model.RequestDir}
+	var message = &model.Message{
+		Id:        &id,
+		Payload:   "pickled eggs",
+		Channel:   testChannelName,
+		Direction: model.RequestDir}
 
-    channel.Send(message)
-    channel.wg.Wait()
-    h.runCount = 1
-    channel.Send(message)
-    assert.Len(t, channel.eventHandlers, 0)
-    assert.Equal(t, 1, count)
+	channel.Send(message)
+	channel.wg.Wait()
+	h.runCount = 1
+	channel.Send(message)
+	assert.Len(t, channel.eventHandlers, 0)
+	assert.Equal(t, 1, count)
 }
 
-
-
-
 func TestChannel_SendMultipleMessages(t *testing.T) {
-    id := uuid.New()
-    channel := NewChannel(testChannelName)
-    var counter int32 = 0
-    handler := func(message *model.Message) {
-        assert.Equal(t, message.Payload.(string), "chewy louie")
-        assert.Equal(t, message.Channel, testChannelName)
-        inc(&counter)
-    }
+	id := uuid.New()
+	channel := NewChannel(testChannelName)
+	var counter int32 = 0
+	handler := func(message *model.Message) {
+		assert.Equal(t, message.Payload.(string), "chewy louie")
+		assert.Equal(t, message.Channel, testChannelName)
+		inc(&counter)
+	}
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
-    var message = &model.Message{
-        Id:        &id,
-        Payload:   "chewy louie",
-        Channel:   testChannelName,
-        Direction: model.RequestDir}
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	var message = &model.Message{
+		Id:        &id,
+		Payload:   "chewy louie",
+		Channel:   testChannelName,
+		Direction: model.RequestDir}
 
-    channel.Send(message)
-    channel.Send(message)
-    channel.Send(message)
-    channel.wg.Wait()
-    assert.Equal(t, int32(3), counter)
+	channel.Send(message)
+	channel.Send(message)
+	channel.Send(message)
+	channel.wg.Wait()
+	assert.Equal(t, int32(3), counter)
 }
 
 func TestChannel_MultiHandlerSingleMessage(t *testing.T) {
-    id := uuid.New()
-    channel := NewChannel(testChannelName)
-    var counterA, counterB, counterC int32 = 0, 0, 0
+	id := uuid.New()
+	channel := NewChannel(testChannelName)
+	var counterA, counterB, counterC int32 = 0, 0, 0
 
-    handlerA := func(message *model.Message) {
-        inc(&counterA)
-    }
-    handlerB := func(message *model.Message) {
-        inc(&counterB)
-    }
-    handlerC := func(message *model.Message) {
-        inc(&counterC)
-    }
+	handlerA := func(message *model.Message) {
+		inc(&counterA)
+	}
+	handlerB := func(message *model.Message) {
+		inc(&counterB)
+	}
+	handlerC := func(message *model.Message) {
+		inc(&counterC)
+	}
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerA, runOnce: false, uuid: &id})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerA, runOnce: false, uuid: &id})
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerB, runOnce: false, uuid: &id})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerB, runOnce: false, uuid: &id})
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerC, runOnce: false, uuid: &id})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerC, runOnce: false, uuid: &id})
 
-    var message = &model.Message{
-        Id:        &id,
-        Payload:   "late night munchies",
-        Channel:   testChannelName,
-        Direction: model.RequestDir}
+	var message = &model.Message{
+		Id:        &id,
+		Payload:   "late night munchies",
+		Channel:   testChannelName,
+		Direction: model.RequestDir}
 
-    channel.Send(message)
-    channel.Send(message)
-    channel.Send(message)
-    channel.wg.Wait()
-    value := counterA + counterB + counterC
+	channel.Send(message)
+	channel.Send(message)
+	channel.Send(message)
+	channel.wg.Wait()
+	value := counterA + counterB + counterC
 
-    assert.Equal(t, int32(9), value)
+	assert.Equal(t, int32(9), value)
 }
 
 func TestChannel_Privacy(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    assert.False(t, channel.private)
-    channel.SetPrivate(true)
-    assert.True(t, channel.IsPrivate())
+	channel := NewChannel(testChannelName)
+	assert.False(t, channel.private)
+	channel.SetPrivate(true)
+	assert.True(t, channel.IsPrivate())
 }
 
 func TestChannel_ChannelGalactic(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    assert.False(t, channel.galactic)
-    channel.SetGalactic("somewhere")
-    assert.True(t, channel.IsGalactic())
+	channel := NewChannel(testChannelName)
+	assert.False(t, channel.galactic)
+	channel.SetGalactic("somewhere")
+	assert.True(t, channel.IsGalactic())
 }
 
 func TestChannel_RemoveEventHandler(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    handlerA := func(message *model.Message) {}
-    handlerB := func(message *model.Message) {}
+	channel := NewChannel(testChannelName)
+	handlerA := func(message *model.Message) {}
+	handlerB := func(message *model.Message) {}
 
-    idA := uuid.New()
-    idB := uuid.New()
+	idA := uuid.New()
+	idB := uuid.New()
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerA, runOnce: false, uuid: &idA})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerA, runOnce: false, uuid: &idA})
 
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerB, runOnce: false, uuid: &idB})
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handlerB, runOnce: false, uuid: &idB})
 
-    assert.Len(t, channel.eventHandlers, 2)
+	assert.Len(t, channel.eventHandlers, 2)
 
-    // remove the first handler (A)
-    channel.removeEventHandler(0)
-    assert.Len(t, channel.eventHandlers, 1)
-    assert.Equal(t, idB.String(), channel.eventHandlers[0].uuid.String())
+	// remove the first handler (A)
+	channel.removeEventHandler(0)
+	assert.Len(t, channel.eventHandlers, 1)
+	assert.Equal(t, idB.String(), channel.eventHandlers[0].uuid.String())
 
-    // remove the second handler B)
-    channel.removeEventHandler(0)
-    assert.True(t, len(channel.eventHandlers) == 0)
+	// remove the second handler B)
+	channel.removeEventHandler(0)
+	assert.True(t, len(channel.eventHandlers) == 0)
 
 }
 
 func TestChannel_RemoveEventHandlerNoHandlers(t *testing.T) {
-    channel := NewChannel(testChannelName)
+	channel := NewChannel(testChannelName)
 
-    channel.removeEventHandler(0)
-    assert.Len(t, channel.eventHandlers, 0)
+	channel.removeEventHandler(0)
+	assert.Len(t, channel.eventHandlers, 0)
 }
 
 func TestChannel_RemoveEventHandlerOOBIndex(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    id := uuid.New()
-    handler := func(*model.Message) {}
-    channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
+	channel := NewChannel(testChannelName)
+	id := uuid.New()
+	handler := func(*model.Message) {}
+	channel.subscribeHandler(&channelEventHandler{callBackFunction: handler, runOnce: false, uuid: &id})
 
-    channel.removeEventHandler(999)
-    assert.Len(t, channel.eventHandlers, 1)
+	channel.removeEventHandler(999)
+	assert.Len(t, channel.eventHandlers, 1)
 }
 
 func TestChannel_AddRemoveBrokerSubscription(t *testing.T) {
-    channel := NewChannel(testChannelName)
-    id := uuid.New()
-    sub := &MockBridgeSubscription{Id: &id}
-    c := &MockBridgeConnection{Id: &id}
-    channel.addBrokerSubscription(c, sub)
-    assert.Len(t, channel.brokerSubs, 1)
-    channel.removeBrokerSubscription(sub)
-    assert.Len(t, channel.brokerSubs, 0)
+	channel := NewChannel(testChannelName)
+	id := uuid.New()
+	sub := &MockBridgeSubscription{Id: &id}
+	c := &MockBridgeConnection{Id: &id}
+	channel.addBrokerSubscription(c, sub)
+	assert.Len(t, channel.brokerSubs, 1)
+	channel.removeBrokerSubscription(sub)
+	assert.Len(t, channel.brokerSubs, 0)
 }
-
 
 func TestChannel_CheckIfBrokerSubscribed(t *testing.T) {
 
-    cId := uuid.New()
-    sId := uuid.New()
-    sId2 := uuid.New()
+	cId := uuid.New()
+	sId := uuid.New()
+	sId2 := uuid.New()
 
-    c := &MockBridgeConnection{
-        Id: &cId,
-    }
-    s := &MockBridgeSubscription{Id: &sId}
-    s2 := &MockBridgeSubscription{Id: &sId2}
+	c := &MockBridgeConnection{
+		Id: &cId,
+	}
+	s := &MockBridgeSubscription{Id: &sId}
+	s2 := &MockBridgeSubscription{Id: &sId2}
 
-    cm := NewBusChannelManager(GetBus())
-    ch := cm.CreateChannel("testing-broker-subs")
-    ch.addBrokerSubscription(c, s)
-    assert.True(t, ch.isBrokerSubscribed(s))
-    assert.False(t, ch.isBrokerSubscribed(s2))
+	cm := NewBusChannelManager(GetBus())
+	ch := cm.CreateChannel("testing-broker-subs")
+	ch.addBrokerSubscription(c, s)
+	assert.True(t, ch.isBrokerSubscribed(s))
+	assert.False(t, ch.isBrokerSubscribed(s2))
 
-    ch.removeBrokerSubscription(s)
-    assert.False(t, ch.isBrokerSubscribed(s))
+	ch.removeBrokerSubscription(s)
+	assert.False(t, ch.isBrokerSubscribed(s))
 }
 
 type MockBridgeConnection struct {
-    mock.Mock
-    Id *uuid.UUID
+	mock.Mock
+	Id *uuid.UUID
 }
 
 func (c *MockBridgeConnection) GetId() *uuid.UUID {
-    return c.Id
+	return c.Id
+}
+
+func (c *MockBridgeConnection) SubscribeReplyDestination(destination string) (bridge.Subscription, error) {
+	args := c.MethodCalled("Subscribe", destination)
+	return args.Get(0).(bridge.Subscription), args.Error(1)
 }
 
 func (c *MockBridgeConnection) Subscribe(destination string) (bridge.Subscription, error) {
-    args := c.MethodCalled("Subscribe", destination)
-    return args.Get(0).(bridge.Subscription), args.Error(1)
+	args := c.MethodCalled("Subscribe", destination)
+	return args.Get(0).(bridge.Subscription), args.Error(1)
 }
 
 func (c *MockBridgeConnection) Disconnect() (err error) {
-    return nil
+	return nil
 }
 
 func (c *MockBridgeConnection) SendJSONMessage(destination string, payload []byte, opts ...func(frame *frame.Frame) error) error {
-    args := c.MethodCalled("SendJSONMessage", destination, payload)
-    return args.Error(0)
+	args := c.MethodCalled("SendJSONMessage", destination, payload)
+	return args.Error(0)
 }
 
 func (c *MockBridgeConnection) SendMessage(destination, contentType string, payload []byte, opts ...func(frame *frame.Frame) error) error {
-    args := c.MethodCalled("SendMessage", destination, contentType, payload)
-    return args.Error(0)
+	args := c.MethodCalled("SendMessage", destination, contentType, payload)
+	return args.Error(0)
+}
+
+func (c *MockBridgeConnection) SendMessageWithReplyDestination(destination, reply, contentType string, payload []byte, opts ...func(frame *frame.Frame) error) error {
+	args := c.MethodCalled("SendMessage", destination, contentType, payload)
+	return args.Error(0)
 }
 
 type MockBridgeSubscription struct {
-    Id *uuid.UUID
-    Destination string
-    Channel chan *model.Message
+	Id          *uuid.UUID
+	Destination string
+	Channel     chan *model.Message
 }
 
 func (m *MockBridgeSubscription) GetId() *uuid.UUID {
-    return m.Id
+	return m.Id
 }
 
 func (m *MockBridgeSubscription) GetDestination() string {
-    return m.Destination
+	return m.Destination
 }
 
 func (m *MockBridgeSubscription) GetMsgChannel() chan *model.Message {
-    return m.Channel
+	return m.Channel
 }
 
 func (m *MockBridgeSubscription) Unsubscribe() error {
-    return nil
+	return nil
 }

--- a/bus/fabric_endpoint.go
+++ b/bus/fabric_endpoint.go
@@ -4,301 +4,301 @@
 package bus
 
 import (
-    "encoding/json"
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/vmware/transport-go/log"
-    "github.com/vmware/transport-go/model"
-    "github.com/vmware/transport-go/stompserver"
-    "strings"
-    "sync"
+	"encoding/json"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/vmware/transport-go/log"
+	"github.com/vmware/transport-go/model"
+	"github.com/vmware/transport-go/stompserver"
+	"strings"
+	"sync"
 )
 
 const (
-    STOMP_SESSION_NOTIFY_CHANNEL = TRANSPORT_INTERNAL_CHANNEL_PREFIX + "stomp-session-notify"
+	STOMP_SESSION_NOTIFY_CHANNEL = TRANSPORT_INTERNAL_CHANNEL_PREFIX + "stomp-session-notify"
 )
 
 type EndpointConfig struct {
-    // Prefix for public topics e.g. "/topic"
-    TopicPrefix           string
-    // Prefix for user queues e.g. "/user/queue"
-    UserQueuePrefix       string
-    // Prefix used for public application requests e.g. "/pub"
-    AppRequestPrefix      string
-    // Prefix used for "private" application requests e.g. "/pub/queue"
-    // Requests sent to destinations prefixed with the AppRequestQueuePrefix
-    // should generate responses sent to single client queue.
-    // E.g. if a client sends a request to the "/pub/queue/sample-channel" destination
-    // the application should sent the response only to this client on the
-    // "/user/queue/sample-channel" destination.
-    // This behavior will mimic the Spring SimpleMessageBroker implementation.
-    AppRequestQueuePrefix string
-    Heartbeat             int64
+	// Prefix for public topics e.g. "/topic"
+	TopicPrefix string
+	// Prefix for user queues e.g. "/user/queue"
+	UserQueuePrefix string
+	// Prefix used for public application requests e.g. "/pub"
+	AppRequestPrefix string
+	// Prefix used for "private" application requests e.g. "/pub/queue"
+	// Requests sent to destinations prefixed with the AppRequestQueuePrefix
+	// should generate responses sent to single client queue.
+	// E.g. if a client sends a request to the "/pub/queue/sample-channel" destination
+	// the application should sent the response only to this client on the
+	// "/user/queue/sample-channel" destination.
+	// This behavior will mimic the Spring SimpleMessageBroker implementation.
+	AppRequestQueuePrefix string
+	Heartbeat             int64
 }
 
 func (ec *EndpointConfig) validate() error {
-    if ec.TopicPrefix == "" || !strings.HasPrefix(ec.TopicPrefix, "/") {
-        return fmt.Errorf("invalid TopicPrefix")
-    }
+	if ec.TopicPrefix == "" || !strings.HasPrefix(ec.TopicPrefix, "/") {
+		return fmt.Errorf("invalid TopicPrefix")
+	}
 
-    if ec.AppRequestQueuePrefix != "" && ec.UserQueuePrefix == "" {
-        return fmt.Errorf("missing UserQueuePrefix")
-    }
+	if ec.AppRequestQueuePrefix != "" && ec.UserQueuePrefix == "" {
+		return fmt.Errorf("missing UserQueuePrefix")
+	}
 
-    return nil
+	return nil
 }
 
 type FabricEndpoint interface {
-    Start()
-    Stop()
+	Start()
+	Stop()
 }
 
 type channelMapping struct {
-    subs        map[string]bool
-    handler     MessageHandler
-    autoCreated bool
+	subs        map[string]bool
+	handler     MessageHandler
+	autoCreated bool
 }
 
 type StompSessionEvent struct {
-    Id string
-    EventType stompserver.StompSessionEventType
+	Id        string
+	EventType stompserver.StompSessionEventType
 }
 
 type fabricEndpoint struct {
-    server stompserver.StompServer
-    bus    EventBus
-    config EndpointConfig
-    chanLock sync.RWMutex
-    chanMappings map[string]*channelMapping
+	server       stompserver.StompServer
+	bus          EventBus
+	config       EndpointConfig
+	chanLock     sync.RWMutex
+	chanMappings map[string]*channelMapping
 }
 
 func addPrefixIfNotEmpty(s string, prefix string) string {
-    if s != "" && !strings.HasSuffix(s, prefix) {
-        return s + prefix
-    }
-    return s
+	if s != "" && !strings.HasSuffix(s, prefix) {
+		return s + prefix
+	}
+	return s
 }
 
 func newFabricEndpoint(bus EventBus,
-        conListener stompserver.RawConnectionListener, config EndpointConfig) FabricEndpoint {
+	conListener stompserver.RawConnectionListener, config EndpointConfig) FabricEndpoint {
 
-    config.TopicPrefix = addPrefixIfNotEmpty(config.TopicPrefix, "/")
-    config.AppRequestPrefix = addPrefixIfNotEmpty(config.AppRequestPrefix, "/")
-    config.AppRequestQueuePrefix = addPrefixIfNotEmpty(config.AppRequestQueuePrefix, "/")
-    config.UserQueuePrefix = addPrefixIfNotEmpty(config.UserQueuePrefix, "/")
+	config.TopicPrefix = addPrefixIfNotEmpty(config.TopicPrefix, "/")
+	config.AppRequestPrefix = addPrefixIfNotEmpty(config.AppRequestPrefix, "/")
+	config.AppRequestQueuePrefix = addPrefixIfNotEmpty(config.AppRequestQueuePrefix, "/")
+	config.UserQueuePrefix = addPrefixIfNotEmpty(config.UserQueuePrefix, "/")
 
-    stompConf := stompserver.NewStompConfig(config.Heartbeat,
-            []string{config.AppRequestPrefix, config.AppRequestQueuePrefix})
+	stompConf := stompserver.NewStompConfig(config.Heartbeat,
+		[]string{config.AppRequestPrefix, config.AppRequestQueuePrefix})
 
-    fabricEndpoint := &fabricEndpoint{
-        server:       stompserver.NewStompServer(conListener, stompConf),
-        config:       config,
-        bus:          bus,
-        chanMappings: make(map[string]*channelMapping),
-    }
+	fabricEndpoint := &fabricEndpoint{
+		server:       stompserver.NewStompServer(conListener, stompConf),
+		config:       config,
+		bus:          bus,
+		chanMappings: make(map[string]*channelMapping),
+	}
 
-    fabricEndpoint.initHandlers()
-    return fabricEndpoint
+	fabricEndpoint.initHandlers()
+	return fabricEndpoint
 }
 
 func (fe *fabricEndpoint) Start() {
-    fe.server.SetConnectionEventCallback(stompserver.ConnectionStarting, func(connEvent *stompserver.ConnEvent) {
-        busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
-            Id: connEvent.ConnId,
-            EventType: stompserver.ConnectionStarting,
-        }, nil)
-    })
-    fe.server.SetConnectionEventCallback(stompserver.ConnectionClosed, func(connEvent *stompserver.ConnEvent) {
-        busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
-            Id: connEvent.ConnId,
-            EventType: stompserver.ConnectionClosed,
-        }, nil)
-    })
-    fe.server.SetConnectionEventCallback(stompserver.UnsubscribeFromTopic, func(connEvent *stompserver.ConnEvent) {
-        busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
-            Id: connEvent.ConnId,
-            EventType: stompserver.UnsubscribeFromTopic,
-        }, nil)
-    })
-    fe.server.Start()
+	fe.server.SetConnectionEventCallback(stompserver.ConnectionStarting, func(connEvent *stompserver.ConnEvent) {
+		busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
+			Id:        connEvent.ConnId,
+			EventType: stompserver.ConnectionStarting,
+		}, nil)
+	})
+	fe.server.SetConnectionEventCallback(stompserver.ConnectionClosed, func(connEvent *stompserver.ConnEvent) {
+		busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
+			Id:        connEvent.ConnId,
+			EventType: stompserver.ConnectionClosed,
+		}, nil)
+	})
+	fe.server.SetConnectionEventCallback(stompserver.UnsubscribeFromTopic, func(connEvent *stompserver.ConnEvent) {
+		busInstance.SendResponseMessage(STOMP_SESSION_NOTIFY_CHANNEL, &StompSessionEvent{
+			Id:        connEvent.ConnId,
+			EventType: stompserver.UnsubscribeFromTopic,
+		}, nil)
+	})
+	fe.server.Start()
 }
 
 func (fe *fabricEndpoint) Stop() {
-    fe.server.Stop()
+	fe.server.Stop()
 }
 
 func (fe *fabricEndpoint) initHandlers() {
-    fe.server.OnApplicationRequest(fe.bridgeMessage)
-    fe.server.OnSubscribeEvent(fe.addSubscription)
-    fe.server.OnUnsubscribeEvent(fe.removeSubscription)
+	fe.server.OnApplicationRequest(fe.bridgeMessage)
+	fe.server.OnSubscribeEvent(fe.addSubscription)
+	fe.server.OnUnsubscribeEvent(fe.removeSubscription)
 }
 
 func (fe *fabricEndpoint) addSubscription(
-        conId string, subId string, destination string, frame *frame.Frame) {
+	conId string, subId string, destination string, frame *frame.Frame) {
 
-    channelName, ok := fe.getChannelNameFromSubscription(destination)
-    if !ok {
-        return
-    }
+	channelName, ok := fe.getChannelNameFromSubscription(destination)
+	if !ok {
+		return
+	}
 
-    // if destination is a protected channel do not establish a subscription
-    // (we don't want any clients to be sending messages to internal channels)
-    if isProtectedDestination(channelName) {
-        return
-    }
+	// if destination is a protected channel do not establish a subscription
+	// (we don't want any clients to be sending messages to internal channels)
+	if isProtectedDestination(channelName) {
+		return
+	}
 
-    fe.chanLock.Lock()
-    defer fe.chanLock.Unlock()
+	fe.chanLock.Lock()
+	defer fe.chanLock.Unlock()
 
-    chanMap, ok := fe.chanMappings[channelName]
-    if !ok {
-        messageHandler, err := fe.bus.ListenStream(channelName)
-        var autoCreated = false
-        if messageHandler == nil || err != nil {
-            fe.bus.GetChannelManager().CreateChannel(channelName)
-            messageHandler, err = fe.bus.ListenStream(channelName)
-            if messageHandler == nil || err != nil {
-                log.Warn("Unable to auto-create channel for destination: %s", destination)
-                return
-            }
-            autoCreated = true
-        }
-        messageHandler.Handle(
-            func(message *model.Message) {
-                data, err := marshalMessagePayload(message)
-                if err == nil {
-                    resp, ok := convertPayloadToResponseObj(message)
-                    if ok && resp != nil && resp.BrokerDestination != nil {
-                        fe.server.SendMessageToClient(
-                            resp.BrokerDestination.ConnectionId,
-                            resp.BrokerDestination.Destination,
-                            data)
-                    } else {
-                        fe.server.SendMessage(fe.config.TopicPrefix + channelName, data)
-                    }
-                }
-            },
-            func(e error) {
-                fe.server.SendMessage(destination, []byte(e.Error()))
-            })
+	chanMap, ok := fe.chanMappings[channelName]
+	if !ok {
+		messageHandler, err := fe.bus.ListenStream(channelName)
+		var autoCreated = false
+		if messageHandler == nil || err != nil {
+			fe.bus.GetChannelManager().CreateChannel(channelName)
+			messageHandler, err = fe.bus.ListenStream(channelName)
+			if messageHandler == nil || err != nil {
+				log.Warn("Unable to auto-create channel for destination: %s", destination)
+				return
+			}
+			autoCreated = true
+		}
+		messageHandler.Handle(
+			func(message *model.Message) {
+				data, err := marshalMessagePayload(message)
+				if err == nil {
+					resp, ok := convertPayloadToResponseObj(message)
+					if ok && resp != nil && resp.BrokerDestination != nil {
+						fe.server.SendMessageToClient(
+							resp.BrokerDestination.ConnectionId,
+							resp.BrokerDestination.Destination,
+							data)
+					} else {
+						fe.server.SendMessage(fe.config.TopicPrefix+channelName, data)
+					}
+				}
+			},
+			func(e error) {
+				fe.server.SendMessage(destination, []byte(e.Error()))
+			})
 
-        chanMap = &channelMapping{
-            subs:    make(map[string]bool),
-            handler: messageHandler,
-            autoCreated: autoCreated,
-        }
+		chanMap = &channelMapping{
+			subs:        make(map[string]bool),
+			handler:     messageHandler,
+			autoCreated: autoCreated,
+		}
 
-        fe.chanMappings[channelName] = chanMap
-    }
-    chanMap.subs[conId + "#" + subId] = true
-    fe.bus.SendMonitorEvent(FabricEndpointSubscribeEvt, channelName, nil)
+		fe.chanMappings[channelName] = chanMap
+	}
+	chanMap.subs[conId+"#"+subId] = true
+	fe.bus.SendMonitorEvent(FabricEndpointSubscribeEvt, channelName, nil)
 }
 
 func convertPayloadToResponseObj(message *model.Message) (*model.Response, bool) {
-    var resp model.Response
-    var ok bool
+	var resp model.Response
+	var ok bool
 
-    resp, ok = message.Payload.(model.Response)
-    if ok {
-        return &resp, true
-    }
+	resp, ok = message.Payload.(model.Response)
+	if ok {
+		return &resp, true
+	}
 
-    var respPtr *model.Response
-    respPtr, ok = message.Payload.(*model.Response)
-    if ok {
-        return respPtr, true
-    }
+	var respPtr *model.Response
+	respPtr, ok = message.Payload.(*model.Response)
+	if ok {
+		return respPtr, true
+	}
 
-    return nil, false
+	return nil, false
 }
 
 func marshalMessagePayload(message *model.Message) ([]byte, error) {
-    // don't marshal string and []byte payloads
-    stringPayload, ok := message.Payload.(string)
-    if ok {
-        return []byte(stringPayload), nil
-    }
-    bytePayload, ok := message.Payload.([]byte)
-    if ok {
-        return bytePayload, nil
-    }
-    // encode the message payload as JSON
-    return json.Marshal(message.Payload)
+	// don't marshal string and []byte payloads
+	stringPayload, ok := message.Payload.(string)
+	if ok {
+		return []byte(stringPayload), nil
+	}
+	bytePayload, ok := message.Payload.([]byte)
+	if ok {
+		return bytePayload, nil
+	}
+	// encode the message payload as JSON
+	return json.Marshal(message.Payload)
 }
 
 func (fe *fabricEndpoint) removeSubscription(conId string, subId string, destination string) {
 
-    channelName, ok := fe.getChannelNameFromSubscription(destination)
-    if !ok {
-        return
-    }
+	channelName, ok := fe.getChannelNameFromSubscription(destination)
+	if !ok {
+		return
+	}
 
-    fe.chanLock.Lock()
-    defer fe.chanLock.Unlock()
+	fe.chanLock.Lock()
+	defer fe.chanLock.Unlock()
 
-    chanMap, ok := fe.chanMappings[channelName]
-    if ok {
-        mappingId := conId + "#" + subId
-        if chanMap.subs[mappingId] {
-            delete(chanMap.subs, mappingId)
-            if len(chanMap.subs) == 0 {
-                // if this was the last subscription to the channel,
-                // close the message handler and remove the channel mapping
-                chanMap.handler.Close()
-                delete(fe.chanMappings, channelName)
-                if chanMap.autoCreated {
-                    fe.bus.GetChannelManager().DestroyChannel(channelName)
-                }
-            }
-            fe.bus.SendMonitorEvent(FabricEndpointUnsubscribeEvt, channelName, nil)
-        }
-    }
+	chanMap, ok := fe.chanMappings[channelName]
+	if ok {
+		mappingId := conId + "#" + subId
+		if chanMap.subs[mappingId] {
+			delete(chanMap.subs, mappingId)
+			if len(chanMap.subs) == 0 {
+				// if this was the last subscription to the channel,
+				// close the message handler and remove the channel mapping
+				chanMap.handler.Close()
+				delete(fe.chanMappings, channelName)
+				if chanMap.autoCreated {
+					fe.bus.GetChannelManager().DestroyChannel(channelName)
+				}
+			}
+			fe.bus.SendMonitorEvent(FabricEndpointUnsubscribeEvt, channelName, nil)
+		}
+	}
 }
 
 func (fe *fabricEndpoint) bridgeMessage(destination string, message []byte, connectionId string) {
-    var channelName string
-    isPrivateRequest := false
+	var channelName string
+	isPrivateRequest := false
 
-    if fe.config.AppRequestQueuePrefix != "" && strings.HasPrefix(destination, fe.config.AppRequestQueuePrefix) {
-        channelName = destination[len(fe.config.AppRequestQueuePrefix):]
-        isPrivateRequest = true
-    } else if fe.config.AppRequestPrefix != "" && strings.HasPrefix(destination, fe.config.AppRequestPrefix) {
-        channelName = destination[len(fe.config.AppRequestPrefix):]
-    } else {
-        return
-    }
+	if fe.config.AppRequestQueuePrefix != "" && strings.HasPrefix(destination, fe.config.AppRequestQueuePrefix) {
+		channelName = destination[len(fe.config.AppRequestQueuePrefix):]
+		isPrivateRequest = true
+	} else if fe.config.AppRequestPrefix != "" && strings.HasPrefix(destination, fe.config.AppRequestPrefix) {
+		channelName = destination[len(fe.config.AppRequestPrefix):]
+	} else {
+		return
+	}
 
-    var req model.Request
-    err := json.Unmarshal(message, &req)
-    if err != nil {
-        log.Warn("Failed to deserialize request for channel %s", channelName)
-        return
-    }
+	var req model.Request
+	err := json.Unmarshal(message, &req)
+	if err != nil {
+		log.Warn("Failed to deserialize request for channel %s", channelName)
+		return
+	}
 
-    if isPrivateRequest {
-        req.BrokerDestination = &model.BrokerDestinationConfig{
-            Destination: fe.config.UserQueuePrefix + channelName,
-            ConnectionId: connectionId,
-        }
-    }
+	if isPrivateRequest {
+		req.BrokerDestination = &model.BrokerDestinationConfig{
+			Destination:  fe.config.UserQueuePrefix + channelName,
+			ConnectionId: connectionId,
+		}
+	}
 
-    fe.bus.SendRequestMessage(channelName, &req, nil)
+	fe.bus.SendRequestMessage(channelName, &req, nil)
 }
 
 func (fe *fabricEndpoint) getChannelNameFromSubscription(destination string) (channelName string, ok bool) {
-    if strings.HasPrefix(destination, fe.config.TopicPrefix) {
-        return destination[len(fe.config.TopicPrefix):], true
-    }
+	if strings.HasPrefix(destination, fe.config.TopicPrefix) {
+		return destination[len(fe.config.TopicPrefix):], true
+	}
 
-    if fe.config.UserQueuePrefix != "" && strings.HasPrefix(destination, fe.config.UserQueuePrefix) {
-        return destination[len(fe.config.UserQueuePrefix):], true
-    }
-    return "", false
+	if fe.config.UserQueuePrefix != "" && strings.HasPrefix(destination, fe.config.UserQueuePrefix) {
+		return destination[len(fe.config.UserQueuePrefix):], true
+	}
+	return "", false
 }
 
 // isProtectedDestination checks if the destination is protected. this utility function is used to
 // prevent messages being from clients to the protected destinations. such examples would be
 // internal bus channels prefixed with _transportInternal/
 func isProtectedDestination(destination string) bool {
-    return strings.HasPrefix(destination, TRANSPORT_INTERNAL_CHANNEL_PREFIX)
+	return strings.HasPrefix(destination, TRANSPORT_INTERNAL_CHANNEL_PREFIX)
 }

--- a/bus/store_manager.go
+++ b/bus/store_manager.go
@@ -4,172 +4,172 @@
 package bus
 
 import (
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "github.com/vmware/transport-go/bridge"
-    "reflect"
-    "strings"
-    "sync"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"github.com/vmware/transport-go/bridge"
+	"reflect"
+	"strings"
+	"sync"
 )
 
 // StoreManager interface controls all access to BusStores
 type StoreManager interface {
-    // Create a new Store, if the store already exists, then it will be returned.
-    CreateStore(name string) BusStore
-    // Create a new Store and use the itemType to deserialize item values when handling
-    // incoming UpdateStoreRequest. If the store already exists, the method will return
-    // the existing store instance.
-    CreateStoreWithType(name string, itemType reflect.Type) BusStore
-    // Get a reference to the existing store. Returns nil if the store doesn't exist.
-    GetStore(name string) BusStore
-    // Deletes a store.
-    DestroyStore(name string) bool
-    // Configure galactic store sync channel for a given connection.
-    // Should be called before OpenGalacticStore() and OpenGalacticStoreWithItemType() APIs.
-    ConfigureStoreSyncChannel(conn bridge.Connection, topicPrefix string, pubPrefix string) error
-    // Open new galactic store
-    OpenGalacticStore(name string, conn bridge.Connection) (BusStore, error)
-    // Open new galactic store and deserialize items from server to itemType
-    OpenGalacticStoreWithItemType(name string, conn bridge.Connection, itemType reflect.Type) (BusStore, error)
+	// Create a new Store, if the store already exists, then it will be returned.
+	CreateStore(name string) BusStore
+	// Create a new Store and use the itemType to deserialize item values when handling
+	// incoming UpdateStoreRequest. If the store already exists, the method will return
+	// the existing store instance.
+	CreateStoreWithType(name string, itemType reflect.Type) BusStore
+	// Get a reference to the existing store. Returns nil if the store doesn't exist.
+	GetStore(name string) BusStore
+	// Deletes a store.
+	DestroyStore(name string) bool
+	// Configure galactic store sync channel for a given connection.
+	// Should be called before OpenGalacticStore() and OpenGalacticStoreWithItemType() APIs.
+	ConfigureStoreSyncChannel(conn bridge.Connection, topicPrefix string, pubPrefix string) error
+	// Open new galactic store
+	OpenGalacticStore(name string, conn bridge.Connection) (BusStore, error)
+	// Open new galactic store and deserialize items from server to itemType
+	OpenGalacticStoreWithItemType(name string, conn bridge.Connection, itemType reflect.Type) (BusStore, error)
 }
 
 // Interface which is a subset of the bridge.Connection methods.
 // Used to mock connection objects during unit testing.
 type galacticStoreConnection interface {
-    SendJSONMessage(destination string, payload []byte, opts ...func(frame *frame.Frame) error) error
-    SendMessage(destination, contentType string, payload []byte, opts ...func(frame *frame.Frame) error) error
+	SendJSONMessage(destination string, payload []byte, opts ...func(frame *frame.Frame) error) error
+	SendMessage(destination, contentType string, payload []byte, opts ...func(frame *frame.Frame) error) error
 }
 
 type storeSyncChannelConfig struct {
-    topicPrefix     string
-    pubPrefix       string
-    syncChannelName string
-    conn            galacticStoreConnection
+	topicPrefix     string
+	pubPrefix       string
+	syncChannelName string
+	conn            galacticStoreConnection
 }
 
 type storeManager struct {
-    stores           map[string]BusStore
-    storesLock       sync.RWMutex
-    eventBus         EventBus
-    syncChannelsLock sync.RWMutex
-    syncChannels     map[uuid.UUID]*storeSyncChannelConfig
+	stores           map[string]BusStore
+	storesLock       sync.RWMutex
+	eventBus         EventBus
+	syncChannelsLock sync.RWMutex
+	syncChannels     map[uuid.UUID]*storeSyncChannelConfig
 }
 
 func newStoreManager(eventBus EventBus) StoreManager {
-    m := new(storeManager)
-    m.stores = make(map[string] BusStore)
-    m.syncChannels = make(map[uuid.UUID]*storeSyncChannelConfig)
-    m.eventBus = eventBus
+	m := new(storeManager)
+	m.stores = make(map[string]BusStore)
+	m.syncChannels = make(map[uuid.UUID]*storeSyncChannelConfig)
+	m.eventBus = eventBus
 
-    return m
+	return m
 }
 
 func (m *storeManager) CreateStore(name string) BusStore {
-    return m.CreateStoreWithType(name, nil)
+	return m.CreateStoreWithType(name, nil)
 }
 
 func (m *storeManager) CreateStoreWithType(name string, itemType reflect.Type) BusStore {
-    m.storesLock.Lock()
-    defer m.storesLock.Unlock()
+	m.storesLock.Lock()
+	defer m.storesLock.Unlock()
 
-    store, ok := m.stores[name]
+	store, ok := m.stores[name]
 
-    if ok {
-        return store
-    }
+	if ok {
+		return store
+	}
 
-    m.stores[name] = newBusStore(name, m.eventBus, itemType, nil)
-    go m.eventBus.SendMonitorEvent(StoreCreatedEvt, name, nil)
-    return m.stores[name]
+	m.stores[name] = newBusStore(name, m.eventBus, itemType, nil)
+	go m.eventBus.SendMonitorEvent(StoreCreatedEvt, name, nil)
+	return m.stores[name]
 }
 
 func (m *storeManager) GetStore(name string) BusStore {
-    m.storesLock.RLock()
-    defer m.storesLock.RUnlock()
+	m.storesLock.RLock()
+	defer m.storesLock.RUnlock()
 
-    return m.stores[name]
+	return m.stores[name]
 }
 
 func (m *storeManager) DestroyStore(name string) bool {
-    m.storesLock.Lock()
-    defer m.storesLock.Unlock()
+	m.storesLock.Lock()
+	defer m.storesLock.Unlock()
 
-    store, ok := m.stores[name]
-    if ok {
-        store.(*busStore).OnDestroy()
-        delete(m.stores, name)
+	store, ok := m.stores[name]
+	if ok {
+		store.(*busStore).OnDestroy()
+		delete(m.stores, name)
 
-        go m.eventBus.SendMonitorEvent(StoreDestroyedEvt, name, nil)
-    }
-    return ok
+		go m.eventBus.SendMonitorEvent(StoreDestroyedEvt, name, nil)
+	}
+	return ok
 }
 
 func (m *storeManager) ConfigureStoreSyncChannel(
-        conn bridge.Connection, topicPrefix string, pubPrefix string) error {
+	conn bridge.Connection, topicPrefix string, pubPrefix string) error {
 
-    m.syncChannelsLock.Lock()
-    defer m.syncChannelsLock.Unlock()
+	m.syncChannelsLock.Lock()
+	defer m.syncChannelsLock.Unlock()
 
-    _, ok := m.syncChannels[*conn.GetId()]
-    if ok {
-        return fmt.Errorf("store sync channel already configured for this connection")
-    }
+	_, ok := m.syncChannels[*conn.GetId()]
+	if ok {
+		return fmt.Errorf("store sync channel already configured for this connection")
+	}
 
-    if !strings.HasSuffix(topicPrefix, "/") {
-        topicPrefix += "/"
-    }
-    if !strings.HasSuffix(pubPrefix, "/") {
-        pubPrefix += "/"
-    }
+	if !strings.HasSuffix(topicPrefix, "/") {
+		topicPrefix += "/"
+	}
+	if !strings.HasSuffix(pubPrefix, "/") {
+		pubPrefix += "/"
+	}
 
-    syncChannel := "transport-store-sync." + conn.GetId().String()
+	syncChannel := "transport-store-sync." + conn.GetId().String()
 
-    storeSyncChannelConfig := &storeSyncChannelConfig{
-        topicPrefix:     topicPrefix,
-        pubPrefix:       pubPrefix,
-        syncChannelName: syncChannel,
-        conn:            conn,
-    }
-    m.syncChannels[*conn.GetId()] = storeSyncChannelConfig
+	storeSyncChannelConfig := &storeSyncChannelConfig{
+		topicPrefix:     topicPrefix,
+		pubPrefix:       pubPrefix,
+		syncChannelName: syncChannel,
+		conn:            conn,
+	}
+	m.syncChannels[*conn.GetId()] = storeSyncChannelConfig
 
-    m.eventBus.GetChannelManager().CreateChannel(syncChannel)
-    m.eventBus.GetChannelManager().MarkChannelAsGalactic(syncChannel, topicPrefix + syncChannel, conn)
+	m.eventBus.GetChannelManager().CreateChannel(syncChannel)
+	m.eventBus.GetChannelManager().MarkChannelAsGalactic(syncChannel, topicPrefix+syncChannel, conn)
 
-    return nil
+	return nil
 }
 
 func (m *storeManager) OpenGalacticStore(name string, conn bridge.Connection) (BusStore, error) {
-    return m.OpenGalacticStoreWithItemType(name, conn, nil)
+	return m.OpenGalacticStoreWithItemType(name, conn, nil)
 }
 
 func (m *storeManager) OpenGalacticStoreWithItemType(
-        name string, conn bridge.Connection, itemType reflect.Type) (BusStore, error) {
+	name string, conn bridge.Connection, itemType reflect.Type) (BusStore, error) {
 
-    m.syncChannelsLock.RLock()
-    chanConf, ok := m.syncChannels[*conn.GetId()]
-    m.syncChannelsLock.RUnlock()
+	m.syncChannelsLock.RLock()
+	chanConf, ok := m.syncChannels[*conn.GetId()]
+	m.syncChannelsLock.RUnlock()
 
-    if !ok {
-        return nil, fmt.Errorf("sync channel is not configured for this connection")
-    }
+	if !ok {
+		return nil, fmt.Errorf("sync channel is not configured for this connection")
+	}
 
-    m.storesLock.Lock()
-    defer m.storesLock.Unlock()
+	m.storesLock.Lock()
+	defer m.storesLock.Unlock()
 
-    store, ok := m.stores[name]
+	store, ok := m.stores[name]
 
-    if ok {
-        if store.IsGalactic() {
-            return store, nil
-        } else {
-            return store, fmt.Errorf("cannot open galactic store: there is a local store with the same name")
-        }
-    }
+	if ok {
+		if store.IsGalactic() {
+			return store, nil
+		} else {
+			return store, fmt.Errorf("cannot open galactic store: there is a local store with the same name")
+		}
+	}
 
-    m.stores[name] = newBusStore(name, m.eventBus, itemType, &galacticStoreConfig{
-        syncChannelConfig: chanConf,
-    })
-    go m.eventBus.SendMonitorEvent(StoreCreatedEvt, name, nil)
-    return m.stores[name], nil
+	m.stores[name] = newBusStore(name, m.eventBus, itemType, &galacticStoreConfig{
+		syncChannelConfig: chanConf,
+	})
+	go m.eventBus.SendMonitorEvent(StoreCreatedEvt, name, nil)
+	return m.stores[name], nil
 }

--- a/bus/store_test.go
+++ b/bus/store_test.go
@@ -4,514 +4,512 @@
 package bus
 
 import (
-    "encoding/json"
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/stretchr/testify/assert"
-    "reflect"
-    "sync"
-    "sync/atomic"
-    "testing"
+	"encoding/json"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
 )
 
 type testItem struct {
-    name      string
-    nameIndex int32
+	name      string
+	nameIndex int32
 }
 
 func testStore() BusStore {
-    store := newBusStore("testStore", newTestEventBus(), nil, nil)
-    store.Initialize()
-    return store
+	store := newBusStore("testStore", newTestEventBus(), nil, nil)
+	store.Initialize()
+	return store
 }
 
 type mockGalacticStoreConnection struct {
-    messages  []map[string]interface{}
-    topics []string
-    opts []func(fr *frame.Frame) error
+	messages []map[string]interface{}
+	topics   []string
+	opts     []func(fr *frame.Frame) error
 }
 
 func (con *mockGalacticStoreConnection) SendJSONMessage(destination string, payload []byte, opts ...func(*frame.Frame) error) error {
-    return con.SendMessage(destination, "application/json", payload, opts...)
+	return con.SendMessage(destination, "application/json", payload, opts...)
 }
 
 func (con *mockGalacticStoreConnection) SendMessage(destination, contentType string, payload []byte, opts ...func(*frame.Frame) error) error {
-    var msgPayload map[string]interface{}
-    json.Unmarshal(payload, &msgPayload)
-    con.messages = append(con.messages, msgPayload)
-    con.topics = append(con.topics, destination)
-    con.opts = opts
-    return nil
+	var msgPayload map[string]interface{}
+	json.Unmarshal(payload, &msgPayload)
+	con.messages = append(con.messages, msgPayload)
+	con.topics = append(con.topics, destination)
+	con.opts = opts
+	return nil
 }
 
 func (con *mockGalacticStoreConnection) lastMessage() map[string]interface{} {
-    n := len(con.messages)
-    return con.messages[n-1]
+	n := len(con.messages)
+	return con.messages[n-1]
 }
 
 func (con *mockGalacticStoreConnection) lastTopic() string {
-    n := len(con.topics)
-    return con.topics[n-1]
+	n := len(con.topics)
+	return con.topics[n-1]
 }
 
 func testGalacticStore(itemType reflect.Type) (BusStore, *mockGalacticStoreConnection, EventBus) {
 
-    bus := newTestEventBus()
-    bus.GetChannelManager().CreateChannel("sync-channel")
+	bus := newTestEventBus()
+	bus.GetChannelManager().CreateChannel("sync-channel")
 
-    conn := &mockGalacticStoreConnection{
-        messages: make([]map[string]interface{}, 0),
-        topics: make([]string,0),
-        opts: make([]func(*frame.Frame) error, 0),
-    }
+	conn := &mockGalacticStoreConnection{
+		messages: make([]map[string]interface{}, 0),
+		topics:   make([]string, 0),
+		opts:     make([]func(*frame.Frame) error, 0),
+	}
 
-    conf := &galacticStoreConfig{
-        syncChannelConfig: &storeSyncChannelConfig{
-            syncChannelName: "sync-channel",
-            conn: conn,
-            pubPrefix: "/pub/",
-        },
-    }
+	conf := &galacticStoreConfig{
+		syncChannelConfig: &storeSyncChannelConfig{
+			syncChannelName: "sync-channel",
+			conn:            conn,
+			pubPrefix:       "/pub/",
+		},
+	}
 
-    store := newBusStore("testStore", bus, itemType, conf)
-    return store, conn, bus
+	store := newBusStore("testStore", bus, itemType, conf)
+	return store, conn, bus
 }
 
 func TestBusStore_CreateStore(t *testing.T) {
-    store := testStore()
-    assert.Equal(t, store.GetName(), "testStore")
-    assert.False(t, store.IsGalactic())
+	store := testStore()
+	assert.Equal(t, store.GetName(), "testStore")
+	assert.False(t, store.IsGalactic())
 }
 
 func TestBusStore_PutAndGet(t *testing.T) {
-    store := testStore()
-    store.Put("id1", 1, "ITEM_ADDED")
-    store.Put("id2", "value2", "ITEM_ADDED")
-    store.Put("id3", nil, "ITEM_ADDED")
+	store := testStore()
+	store.Put("id1", 1, "ITEM_ADDED")
+	store.Put("id2", "value2", "ITEM_ADDED")
+	store.Put("id3", nil, "ITEM_ADDED")
 
-    v, ok := store.Get("id1")
-    assert.Equal(t, v, 1)
-    assert.True(t, ok)
+	v, ok := store.Get("id1")
+	assert.Equal(t, v, 1)
+	assert.True(t, ok)
 
-    v, _ = store.Get("id2")
-    assert.Equal(t, v, "value2")
+	v, _ = store.Get("id2")
+	assert.Equal(t, v, "value2")
 
-    v, ok = store.Get("id3")
-    assert.Equal(t, v, nil)
-    assert.True(t, ok)
+	v, ok = store.Get("id3")
+	assert.Equal(t, v, nil)
+	assert.True(t, ok)
 
-    v, ok = store.Get("invalid-id")
-    assert.False(t, ok)
-    assert.Nil(t, v)
+	v, ok = store.Get("invalid-id")
+	assert.False(t, ok)
+	assert.Nil(t, v)
 }
 
 func TestBusStore_Remove(t *testing.T) {
-    store := testStore()
-    store.Put("id1", "item1", "ITEM_ADDED")
+	store := testStore()
+	store.Put("id1", "item1", "ITEM_ADDED")
 
-    var mutationEventsCounter int32 = 0
-    var successfulRemovesCounter int32 = 0
+	var mutationEventsCounter int32 = 0
+	var successfulRemovesCounter int32 = 0
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    stream := store.OnAllChanges("ITEM_REMOVED")
-    stream.Subscribe(func(change *StoreChange) {
-        atomic.AddInt32(&mutationEventsCounter, 1)
-        wg.Done()
-    })
+	stream := store.OnAllChanges("ITEM_REMOVED")
+	stream.Subscribe(func(change *StoreChange) {
+		atomic.AddInt32(&mutationEventsCounter, 1)
+		wg.Done()
+	})
 
-    for i := 0; i < 50; i++ {
-        wg.Add(1)
-        go func() {
-            if store.Remove("id1", "ITEM_REMOVED") {
-                atomic.AddInt32(&successfulRemovesCounter, 1)
-            }
-            wg.Done()
-        }()
-    }
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			if store.Remove("id1", "ITEM_REMOVED") {
+				atomic.AddInt32(&successfulRemovesCounter, 1)
+			}
+			wg.Done()
+		}()
+	}
 
-    wg.Wait()
+	wg.Wait()
 
-    assert.False(t, store.Remove("invalid-id", "ITEM_REMOVED"))
+	assert.False(t, store.Remove("invalid-id", "ITEM_REMOVED"))
 
-    // Verify that only one of the Remove calls was successful (has returned true)
-    assert.Equal(t, successfulRemovesCounter, int32(1))
-    assert.Equal(t, mutationEventsCounter, int32(1))
+	// Verify that only one of the Remove calls was successful (has returned true)
+	assert.Equal(t, successfulRemovesCounter, int32(1))
+	assert.Equal(t, mutationEventsCounter, int32(1))
 }
 
 func TestBusStore_AllValuesAndAllValuesAsMap(t *testing.T) {
-    store := testStore()
+	store := testStore()
 
-    items := store.AllValues()
-    allItemsAsMap := store.AllValuesAsMap()
-    assert.Equal(t, len(items), 0)
-    assert.Equal(t, len(allItemsAsMap), 0)
+	items := store.AllValues()
+	allItemsAsMap := store.AllValuesAsMap()
+	assert.Equal(t, len(items), 0)
+	assert.Equal(t, len(allItemsAsMap), 0)
 
+	store.Put("id1", testItem{name: "item1", nameIndex: 1}, "ITEM_ADDED")
+	store.Put("id2", testItem{name: "item2", nameIndex: 2}, "ITEM_ADDED")
+	store.Put("id3", testItem{name: "item3", nameIndex: 3}, "ITEM_ADDED")
 
-    store.Put("id1", testItem { name: "item1", nameIndex: 1}, "ITEM_ADDED")
-    store.Put("id2", testItem { name: "item2", nameIndex: 2}, "ITEM_ADDED")
-    store.Put("id3", testItem { name: "item3", nameIndex: 3}, "ITEM_ADDED")
+	items = store.AllValues()
+	allItemsAsMap = store.AllValuesAsMap()
 
-    items = store.AllValues()
-    allItemsAsMap = store.AllValuesAsMap()
+	assert.Equal(t, len(items), 3)
+	for _, item := range items {
+		assert.Equal(t, fmt.Sprintf("item%d", item.(testItem).nameIndex), item.(testItem).name)
+	}
 
-    assert.Equal(t, len(items), 3)
-    for _, item := range items {
-        assert.Equal(t, fmt.Sprintf("item%d", item.(testItem).nameIndex), item.(testItem).name)
-    }
+	assert.Equal(t, len(allItemsAsMap), 3)
+	assert.Equal(t, allItemsAsMap["id1"], testItem{name: "item1", nameIndex: 1})
+	assert.Equal(t, allItemsAsMap["id2"], testItem{name: "item2", nameIndex: 2})
+	assert.Equal(t, allItemsAsMap["id3"], testItem{name: "item3", nameIndex: 3})
 
-    assert.Equal(t, len(allItemsAsMap), 3)
-    assert.Equal(t, allItemsAsMap["id1"], testItem { name: "item1", nameIndex: 1})
-    assert.Equal(t, allItemsAsMap["id2"], testItem { name: "item2", nameIndex: 2})
-    assert.Equal(t, allItemsAsMap["id3"], testItem { name: "item3", nameIndex: 3})
-
-    allItemsAsMapWithVer, version := store.AllValuesAndVersion()
-    assert.Equal(t, allItemsAsMap, allItemsAsMapWithVer)
-    assert.Equal(t, version, int64(4))
+	allItemsAsMapWithVer, version := store.AllValuesAndVersion()
+	assert.Equal(t, allItemsAsMap, allItemsAsMapWithVer)
+	assert.Equal(t, version, int64(4))
 }
 
 func TestBusStore_OnChange(t *testing.T) {
-    store := testStore()
+	store := testStore()
 
-    wg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 
-    allChangesStreams := make([]StoreStream, 0)
+	allChangesStreams := make([]StoreStream, 0)
 
-    var allChangesCounter int32 = 0
-    for i := 0; i < 5; i++ {
-        stream := store.OnChange("id1")
-        allChangesStreams = append(allChangesStreams, stream)
-        stream.Subscribe(func(change *StoreChange) {
-            atomic.AddInt32(&allChangesCounter, 1)
-            wg.Done()
-        })
-    }
+	var allChangesCounter int32 = 0
+	for i := 0; i < 5; i++ {
+		stream := store.OnChange("id1")
+		allChangesStreams = append(allChangesStreams, stream)
+		stream.Subscribe(func(change *StoreChange) {
+			atomic.AddInt32(&allChangesCounter, 1)
+			wg.Done()
+		})
+	}
 
-    var itemUpdateCounter int32 = 0
-    for i := 0; i < 5; i++ {
-        store.OnChange("id1", "ITEM_REMOVE", "ITEM_UPDATE").Subscribe(
-            func(change *StoreChange) {
-                atomic.AddInt32(&itemUpdateCounter, 1)
-                wg.Done()
-            })
-    }
+	var itemUpdateCounter int32 = 0
+	for i := 0; i < 5; i++ {
+		store.OnChange("id1", "ITEM_REMOVE", "ITEM_UPDATE").Subscribe(
+			func(change *StoreChange) {
+				atomic.AddInt32(&itemUpdateCounter, 1)
+				wg.Done()
+			})
+	}
 
-    for i := 0; i < 200; i++ {
-        if i % 2 == 0 {
-            wg.Add(10)
-            go func() {
-                store.Put("id1", "newValue", "ITEM_UPDATE")
-            }()
-        } else {
-            wg.Add(5)
-            go func() {
-                store.Put("id1", "newValue", "ITEM_ADD")
-            }()
-        }
-    }
+	for i := 0; i < 200; i++ {
+		if i%2 == 0 {
+			wg.Add(10)
+			go func() {
+				store.Put("id1", "newValue", "ITEM_UPDATE")
+			}()
+		} else {
+			wg.Add(5)
+			go func() {
+				store.Put("id1", "newValue", "ITEM_ADD")
+			}()
+		}
+	}
 
-    wg.Wait()
+	wg.Wait()
 
-    assert.Equal(t, allChangesCounter, int32(1000))
-    assert.Equal(t, itemUpdateCounter, int32(500))
+	assert.Equal(t, allChangesCounter, int32(1000))
+	assert.Equal(t, itemUpdateCounter, int32(500))
 
-    // Unsubscribe all changes listeners
-    for _, stream := range allChangesStreams {
-        stream.Unsubscribe()
-    }
+	// Unsubscribe all changes listeners
+	for _, stream := range allChangesStreams {
+		stream.Unsubscribe()
+	}
 
-    wg.Add(5)
-    store.Put("id1", "newValue", "ITEM_REMOVE")
-    wg.Wait()
+	wg.Add(5)
+	store.Put("id1", "newValue", "ITEM_REMOVE")
+	wg.Wait()
 
-    assert.Equal(t, allChangesCounter, int32(1000))
-    assert.Equal(t, itemUpdateCounter, int32(505))
+	assert.Equal(t, allChangesCounter, int32(1000))
+	assert.Equal(t, itemUpdateCounter, int32(505))
 }
 
 func TestBusStore_OnChangeErrorHandling(t *testing.T) {
-    store := testStore()
-    stream := store.OnChange("id1")
-    e := stream.Unsubscribe()
-    assert.EqualError(t, e, "stream not subscribed")
+	store := testStore()
+	stream := store.OnChange("id1")
+	e := stream.Unsubscribe()
+	assert.EqualError(t, e, "stream not subscribed")
 
-    subscribeErr := stream.Subscribe(func(change *StoreChange) {
-    })
+	subscribeErr := stream.Subscribe(func(change *StoreChange) {
+	})
 
-    assert.Nil(t, subscribeErr)
-    subscribeErr = stream.Subscribe(func(change *StoreChange) {
-    })
-    assert.EqualError(t, subscribeErr, "stream already subscribed")
+	assert.Nil(t, subscribeErr)
+	subscribeErr = stream.Subscribe(func(change *StoreChange) {
+	})
+	assert.EqualError(t, subscribeErr, "stream already subscribed")
 
-    e = stream.Subscribe(nil)
-    assert.EqualError(t, e, "invalid StoreChangeHandlerFunction")
+	e = stream.Subscribe(nil)
+	assert.EqualError(t, e, "invalid StoreChangeHandlerFunction")
 }
 
 func TestBusStore_OnAllChanges(t *testing.T) {
-    store := testStore()
+	store := testStore()
 
-    wg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 
-    var allChangesCounter int32 = 0
-    allChangesStream := store.OnAllChanges()
-    allChangesStream.Subscribe(func(change *StoreChange) {
-        atomic.AddInt32(&allChangesCounter, 1)
-        wg.Done()
-    })
+	var allChangesCounter int32 = 0
+	allChangesStream := store.OnAllChanges()
+	allChangesStream.Subscribe(func(change *StoreChange) {
+		atomic.AddInt32(&allChangesCounter, 1)
+		wg.Done()
+	})
 
-    itemUpdatedStream := store.OnAllChanges("ITEM_UPDATED", "ITEM_REMOVED")
-    var itemUpdateCounter int32 = 0
-    itemUpdatedStream.Subscribe(
-        func(change *StoreChange) {
-            atomic.AddInt32(&itemUpdateCounter, 1)
-            wg.Done()
-        })
+	itemUpdatedStream := store.OnAllChanges("ITEM_UPDATED", "ITEM_REMOVED")
+	var itemUpdateCounter int32 = 0
+	itemUpdatedStream.Subscribe(
+		func(change *StoreChange) {
+			atomic.AddInt32(&itemUpdateCounter, 1)
+			wg.Done()
+		})
 
+	for i := 0; i < 200; i++ {
+		if i%2 == 0 {
+			wg.Add(2)
+			go func() {
+				store.Put("id1", "newValue", "ITEM_UPDATED")
+			}()
+		} else {
+			wg.Add(1)
+			go func() {
+				store.Put("id1", "newValue", "ITEM_ADD")
+			}()
+		}
+	}
 
-    for i := 0; i < 200; i++ {
-        if i % 2 == 0 {
-            wg.Add(2)
-            go func() {
-                store.Put("id1", "newValue", "ITEM_UPDATED")
-            }()
-        } else {
-            wg.Add(1)
-            go func() {
-                store.Put("id1", "newValue", "ITEM_ADD")
-            }()
-        }
-    }
+	wg.Wait()
 
-    wg.Wait()
+	assert.Equal(t, allChangesCounter, int32(200))
+	assert.Equal(t, itemUpdateCounter, int32(100))
 
-    assert.Equal(t, allChangesCounter, int32(200))
-    assert.Equal(t, itemUpdateCounter, int32(100))
+	allChangesStream.Unsubscribe()
 
-    allChangesStream.Unsubscribe()
+	wg.Add(1)
+	store.Put("id1", "newValue", "ITEM_REMOVED")
+	wg.Wait()
 
-    wg.Add(1)
-    store.Put("id1", "newValue", "ITEM_REMOVED")
-    wg.Wait()
-
-    assert.Equal(t, allChangesCounter, int32(200))
-    assert.Equal(t, itemUpdateCounter, int32(101))
+	assert.Equal(t, allChangesCounter, int32(200))
+	assert.Equal(t, itemUpdateCounter, int32(101))
 }
 
 func TestBusStore_WhenReady(t *testing.T) {
-    store := newBusStore("testStore", newTestEventBus(), nil, nil)
+	store := newBusStore("testStore", newTestEventBus(), nil, nil)
 
-    wg := sync.WaitGroup{}
-    var counter int32 = 0
-    for i := 0; i < 100; i++ {
-        wg.Add(1)
-        store.WhenReady(func() {
-            atomic.AddInt32(&counter, 1)
-            wg.Done()
-        })
-    }
+	wg := sync.WaitGroup{}
+	var counter int32 = 0
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		store.WhenReady(func() {
+			atomic.AddInt32(&counter, 1)
+			wg.Done()
+		})
+	}
 
-    store.Initialize()
+	store.Initialize()
 
-    wg.Wait()
-    assert.Equal(t, counter, int32(100))
+	wg.Wait()
+	assert.Equal(t, counter, int32(100))
 
-    for i := 0; i < 100; i++ {
-        wg.Add(1)
-        store.WhenReady(func() {
-            atomic.AddInt32(&counter, 1)
-            wg.Done()
-        })
-    }
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		store.WhenReady(func() {
+			atomic.AddInt32(&counter, 1)
+			wg.Done()
+		})
+	}
 
-    wg.Wait()
-    assert.Equal(t, counter, int32(200))
+	wg.Wait()
+	assert.Equal(t, counter, int32(200))
 }
 
 func TestBusStore_Populate(t *testing.T) {
-    store := newBusStore("testStore", newTestEventBus(), nil, nil)
+	store := newBusStore("testStore", newTestEventBus(), nil, nil)
 
-    wg := sync.WaitGroup{}
-    counter := 0
+	wg := sync.WaitGroup{}
+	counter := 0
 
-    wg.Add(1)
-    store.WhenReady(func() {
-        counter++
-        wg.Done()
-    })
+	wg.Add(1)
+	store.WhenReady(func() {
+		counter++
+		wg.Done()
+	})
 
-    err := store.Populate(map[string]interface{} {
-        "id1":  1,
-        "id2":  2,
-        "id3":  3,
-        "id4":  4,
-    })
+	err := store.Populate(map[string]interface{}{
+		"id1": 1,
+		"id2": 2,
+		"id3": 3,
+		"id4": 4,
+	})
 
-    assert.Nil(t, err)
+	assert.Nil(t, err)
 
-    wg.Wait()
+	wg.Wait()
 
-    assert.Equal(t, counter, 1)
+	assert.Equal(t, counter, 1)
 
-    allValues := store.AllValuesAsMap()
-    assert.Equal(t, len(allValues), 4)
-    assert.Equal(t, allValues["id1"], 1)
-    assert.Equal(t, allValues["id2"], 2)
-    assert.Equal(t, allValues["id3"], 3)
-    assert.Equal(t, allValues["id4"], 4)
+	allValues := store.AllValuesAsMap()
+	assert.Equal(t, len(allValues), 4)
+	assert.Equal(t, allValues["id1"], 1)
+	assert.Equal(t, allValues["id2"], 2)
+	assert.Equal(t, allValues["id3"], 3)
+	assert.Equal(t, allValues["id4"], 4)
 
-    err = store.Populate(map[string]interface{} {
-        "id1":  1,
-    })
+	err = store.Populate(map[string]interface{}{
+		"id1": 1,
+	})
 
-    assert.EqualError(t, err, "store items already initialized")
-    assert.Equal(t, len(store.AllValues()), 4)
+	assert.EqualError(t, err, "store items already initialized")
+	assert.Equal(t, len(store.AllValues()), 4)
 }
 
 func TestBusStore_Reset(t *testing.T) {
-    store := newBusStore("testStore", newTestEventBus(), nil, nil)
-    wg := sync.WaitGroup{}
-    counter := 0
+	store := newBusStore("testStore", newTestEventBus(), nil, nil)
+	wg := sync.WaitGroup{}
+	counter := 0
 
-    wg.Add(1)
-    store.WhenReady(func() {
-        counter++
-        wg.Done()
-    })
+	wg.Add(1)
+	store.WhenReady(func() {
+		counter++
+		wg.Done()
+	})
 
-    store.Populate(map[string]interface{} {
-        "id1":  1,
-        "id2":  2,
-        "id3":  3,
-    })
-    wg.Wait()
+	store.Populate(map[string]interface{}{
+		"id1": 1,
+		"id2": 2,
+		"id3": 3,
+	})
+	wg.Wait()
 
-    store.Reset()
+	store.Reset()
 
-    assert.Equal(t, len(store.AllValues()), 0)
+	assert.Equal(t, len(store.AllValues()), 0)
 
-    wg.Add(1)
-    store.WhenReady(func() {
-        counter++
-        wg.Done()
-    })
+	wg.Add(1)
+	store.WhenReady(func() {
+		counter++
+		wg.Done()
+	})
 
-    store.Initialize()
-    wg.Wait()
-    assert.Equal(t, counter, 2)
+	store.Initialize()
+	wg.Wait()
+	assert.Equal(t, counter, 2)
 }
 
 func TestBusStore_OnMutationRequest(t *testing.T) {
-    store := testStore()
+	store := testStore()
 
-    var allMutationsCounter int32 = 0
-    var responseCount int32 = 0
-    var errorCount int32 = 0
+	var allMutationsCounter int32 = 0
+	var responseCount int32 = 0
+	var errorCount int32 = 0
 
-    allMutationsStream := store.OnMutationRequest()
-    allMutationsStream.Subscribe(func(mutationReq *MutationRequest) {
-        atomic.AddInt32(&allMutationsCounter, 1)
-        mutationReq.SuccessHandler( mutationReq.Request.(string) + "-response")
-    })
+	allMutationsStream := store.OnMutationRequest()
+	allMutationsStream.Subscribe(func(mutationReq *MutationRequest) {
+		atomic.AddInt32(&allMutationsCounter, 1)
+		mutationReq.SuccessHandler(mutationReq.Request.(string) + "-response")
+	})
 
-    var updateMutationsCounter int32 = 0
-    updateMutationStream := store.OnMutationRequest("UPDATE_ITEM", "REMOVE_ITEM")
-    updateMutationStream.Subscribe(func(mutationReq *MutationRequest) {
-        atomic.AddInt32(&updateMutationsCounter, 1)
-        mutationReq.ErrorHandler(mutationReq.Request.(string) + "-error")
-    })
+	var updateMutationsCounter int32 = 0
+	updateMutationStream := store.OnMutationRequest("UPDATE_ITEM", "REMOVE_ITEM")
+	updateMutationStream.Subscribe(func(mutationReq *MutationRequest) {
+		atomic.AddInt32(&updateMutationsCounter, 1)
+		mutationReq.ErrorHandler(mutationReq.Request.(string) + "-error")
+	})
 
-    wg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 
-    for i := 0; i < 100; i++ {
-        req := fmt.Sprintf("req%d", i)
-        wg.Add(2)
-        go func() {
-            store.Mutate(req, "UPDATE_ITEM",
-                func(result interface{}) {
-                    assert.Equal(t, result, req + "-response")
-                    atomic.AddInt32(&responseCount, 1)
-                    wg.Done()
-                },
-                func(err interface{}) {
-                    assert.Equal(t, err, req + "-error")
-                    atomic.AddInt32(&errorCount, 1)
-                    wg.Done()
-                })
-        }()
+	for i := 0; i < 100; i++ {
+		req := fmt.Sprintf("req%d", i)
+		wg.Add(2)
+		go func() {
+			store.Mutate(req, "UPDATE_ITEM",
+				func(result interface{}) {
+					assert.Equal(t, result, req+"-response")
+					atomic.AddInt32(&responseCount, 1)
+					wg.Done()
+				},
+				func(err interface{}) {
+					assert.Equal(t, err, req+"-error")
+					atomic.AddInt32(&errorCount, 1)
+					wg.Done()
+				})
+		}()
 
-        wg.Add(1)
-        go func() {
-            store.Mutate(req, "MODIFY_ITEM",
-                func(result interface{}) {
-                    assert.Equal(t, result, req + "-response")
-                    atomic.AddInt32(&responseCount, 1)
-                    wg.Done()
-                },
-                nil)
-        }()
-    }
+		wg.Add(1)
+		go func() {
+			store.Mutate(req, "MODIFY_ITEM",
+				func(result interface{}) {
+					assert.Equal(t, result, req+"-response")
+					atomic.AddInt32(&responseCount, 1)
+					wg.Done()
+				},
+				nil)
+		}()
+	}
 
-    wg.Wait()
-    assert.Equal(t, allMutationsCounter, int32(200))
-    assert.Equal(t, responseCount, int32(200))
-    assert.Equal(t, updateMutationsCounter, int32(100))
-    assert.Equal(t, errorCount, int32(100))
+	wg.Wait()
+	assert.Equal(t, allMutationsCounter, int32(200))
+	assert.Equal(t, responseCount, int32(200))
+	assert.Equal(t, updateMutationsCounter, int32(100))
+	assert.Equal(t, errorCount, int32(100))
 
-    allMutationsStream.Unsubscribe()
+	allMutationsStream.Unsubscribe()
 
-    wg.Add(1)
-    store.Mutate("req", "UPDATE_ITEM",
-        nil,
-        func(err interface{}) {
-            assert.Equal(t, err, "req-error")
-            atomic.AddInt32(&errorCount, 1)
-            wg.Done()
-        })
-    wg.Wait()
-    assert.Equal(t, allMutationsCounter, int32(200))
-    assert.Equal(t, responseCount, int32(200))
-    assert.Equal(t, updateMutationsCounter, int32(101))
-    assert.Equal(t, errorCount, int32(101))
+	wg.Add(1)
+	store.Mutate("req", "UPDATE_ITEM",
+		nil,
+		func(err interface{}) {
+			assert.Equal(t, err, "req-error")
+			atomic.AddInt32(&errorCount, 1)
+			wg.Done()
+		})
+	wg.Wait()
+	assert.Equal(t, allMutationsCounter, int32(200))
+	assert.Equal(t, responseCount, int32(200))
+	assert.Equal(t, updateMutationsCounter, int32(101))
+	assert.Equal(t, errorCount, int32(101))
 }
 
 func TestBusStore_OnMutationRequest_ErrorHandling(t *testing.T) {
-    store := testStore()
+	store := testStore()
 
-    ms := store.OnMutationRequest()
-    err := ms.Unsubscribe()
+	ms := store.OnMutationRequest()
+	err := ms.Unsubscribe()
 
-    assert.EqualError(t, err, "stream not subscribed")
+	assert.EqualError(t, err, "stream not subscribed")
 
-    err = ms.Subscribe(nil)
-    assert.EqualError(t, err, "invalid MutationRequestHandlerFunction")
+	err = ms.Subscribe(nil)
+	assert.EqualError(t, err, "invalid MutationRequestHandlerFunction")
 
-    ms.Subscribe(func(mutationReq *MutationRequest) {})
+	ms.Subscribe(func(mutationReq *MutationRequest) {})
 
-    err = ms.Subscribe(func(mutationReq *MutationRequest) {})
-    assert.EqualError(t, err, "stream already subscribed")
+	err = ms.Subscribe(func(mutationReq *MutationRequest) {})
+	assert.EqualError(t, err, "stream already subscribed")
 }
 
 func TestBusStore_InitGalacticStore(t *testing.T) {
-    store, conn, bus := testGalacticStore(nil)
+	store, conn, bus := testGalacticStore(nil)
 
-    assert.True(t, store.IsGalactic())
-    assert.EqualError(t, store.Populate(nil), "populate() API is not supported for galactic stores")
+	assert.True(t, store.IsGalactic())
+	assert.EqualError(t, store.Populate(nil), "populate() API is not supported for galactic stores")
 
-    assert.Equal(t, len(conn.messages), 1)
-    assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
-    assert.Equal(t, conn.lastMessage()["request"], "openStore")
+	assert.Equal(t, len(conn.messages), 1)
+	assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
+	assert.Equal(t, conn.lastMessage()["request"], "openStore")
 
-    rq := conn.lastMessage()["payload"].(map[string]interface{})
-    assert.Equal(t, rq["storeId"], "testStore")
+	rq := conn.lastMessage()["payload"].(map[string]interface{})
+	assert.Equal(t, rq["storeId"], "testStore")
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    store.WhenReady(func() {
-        wg.Done()
-    })
+	store.WhenReady(func() {
+		wg.Done()
+	})
 
-    var jsonBlob = []byte(`{
+	var jsonBlob = []byte(`{
         "storeId": "testStore",
         "responseType": "storeContentResponse",
         "items": {
@@ -519,72 +517,72 @@ func TestBusStore_InitGalacticStore(t *testing.T) {
         },
         "storeVersion": 12
     }`)
-    bus.SendResponseMessage("sync-channel", jsonBlob, nil)
+	bus.SendResponseMessage("sync-channel", jsonBlob, nil)
 
-    wg.Wait()
-    assert.Equal(t, len(store.AllValues()), 1)
+	wg.Wait()
+	assert.Equal(t, len(store.AllValues()), 1)
 
-    store.Put("id1", "value1", "add")
-    assert.Equal(t, len(conn.messages), 2)
+	store.Put("id1", "value1", "add")
+	assert.Equal(t, len(conn.messages), 2)
 
-    assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
-    assert.Equal(t, conn.lastMessage()["request"], "updateStore")
-    rq = conn.lastMessage()["payload"].(map[string]interface{})
-    assert.Equal(t, rq["storeId"], "testStore")
-    assert.Equal(t, rq["itemId"], "id1")
-    assert.Equal(t, rq["newItemValue"], "value1")
-    assert.Equal(t, rq["clientStoreVersion"], float64(12))
+	assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
+	assert.Equal(t, conn.lastMessage()["request"], "updateStore")
+	rq = conn.lastMessage()["payload"].(map[string]interface{})
+	assert.Equal(t, rq["storeId"], "testStore")
+	assert.Equal(t, rq["itemId"], "id1")
+	assert.Equal(t, rq["newItemValue"], "value1")
+	assert.Equal(t, rq["clientStoreVersion"], float64(12))
 
-    assert.False(t, store.Remove("id1", "removing"))
-    assert.Equal(t, len(conn.messages), 2)
+	assert.False(t, store.Remove("id1", "removing"))
+	assert.Equal(t, len(conn.messages), 2)
 
-    assert.True(t, store.Remove("id3", "removing"))
-    assert.Equal(t, len(conn.messages), 3)
+	assert.True(t, store.Remove("id3", "removing"))
+	assert.Equal(t, len(conn.messages), 3)
 
-    assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
-    assert.Equal(t, conn.lastMessage()["request"], "updateStore")
-    rq = conn.lastMessage()["payload"].(map[string]interface{})
-    assert.Equal(t, rq["storeId"], "testStore")
-    assert.Equal(t, rq["itemId"], "id3")
-    assert.Equal(t, rq["newItemValue"], nil)
-    assert.Equal(t, rq["clientStoreVersion"], float64(12))
+	assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
+	assert.Equal(t, conn.lastMessage()["request"], "updateStore")
+	rq = conn.lastMessage()["payload"].(map[string]interface{})
+	assert.Equal(t, rq["storeId"], "testStore")
+	assert.Equal(t, rq["itemId"], "id3")
+	assert.Equal(t, rq["newItemValue"], nil)
+	assert.Equal(t, rq["clientStoreVersion"], float64(12))
 
-    store.Reset()
-    assert.Equal(t, len(conn.messages), 4)
-    assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
-    assert.Equal(t, conn.lastMessage()["request"], "openStore")
+	store.Reset()
+	assert.Equal(t, len(conn.messages), 4)
+	assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
+	assert.Equal(t, conn.lastMessage()["request"], "openStore")
 
-    store.(*busStore).OnDestroy()
-    assert.Equal(t, len(conn.messages), 5)
-    assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
-    assert.Equal(t, conn.lastMessage()["request"], "closeStore")
+	store.(*busStore).OnDestroy()
+	assert.Equal(t, len(conn.messages), 5)
+	assert.Equal(t, conn.lastTopic(), "/pub/sync-channel")
+	assert.Equal(t, conn.lastMessage()["request"], "closeStore")
 }
 
 func TestBusStore_GalacticStoreUpdates(t *testing.T) {
-    store, _, bus := testGalacticStore(reflect.TypeOf(MockStoreItem{}))
+	store, _, bus := testGalacticStore(reflect.TypeOf(MockStoreItem{}))
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    var lastStoreChange *StoreChange
+	var lastStoreChange *StoreChange
 
-    store.OnAllChanges().Subscribe(func(change *StoreChange) {
-        lastStoreChange = change
-        wg.Done()
-    })
+	store.OnAllChanges().Subscribe(func(change *StoreChange) {
+		lastStoreChange = change
+		wg.Done()
+	})
 
-    var jsonBlob = []byte(`{
+	var jsonBlob = []byte(`{
         "storeId": "testStore",
         "responseType": "updateStoreResponse",
         "itemId": "id1",
         "newItemValue": { "from": "admin", "message": "value1"},
         "storeVersion": 54
     }`)
-    bus.SendResponseMessage("sync-channel", jsonBlob, nil)
+	bus.SendResponseMessage("sync-channel", jsonBlob, nil)
 
-    bus.SendResponseMessage("sync-channel", []byte("invalid-json}"), nil)
+	bus.SendResponseMessage("sync-channel", []byte("invalid-json}"), nil)
 
-    bus.SendResponseMessage("sync-channel", []byte(`{
+	bus.SendResponseMessage("sync-channel", []byte(`{
         "storeId": "testStore2",
         "responseType": "updateStoreResponse",
         "itemId": "id1",
@@ -592,25 +590,25 @@ func TestBusStore_GalacticStoreUpdates(t *testing.T) {
         "storeVersion": 55
     }`), nil)
 
-    wg.Wait()
+	wg.Wait()
 
-    assert.Equal(t, store.(*busStore).storeVersion, int64(54))
-    assert.NotNil(t, lastStoreChange)
+	assert.Equal(t, store.(*busStore).storeVersion, int64(54))
+	assert.NotNil(t, lastStoreChange)
 
-    assert.Equal(t, lastStoreChange.Id, "id1")
-    assert.Equal(t, lastStoreChange.Value, MockStoreItem{From: "admin", Message:"value1"})
-    assert.Equal(t, store.GetValue("id1"), MockStoreItem{From: "admin", Message:"value1"})
+	assert.Equal(t, lastStoreChange.Id, "id1")
+	assert.Equal(t, lastStoreChange.Value, MockStoreItem{From: "admin", Message: "value1"})
+	assert.Equal(t, store.GetValue("id1"), MockStoreItem{From: "admin", Message: "value1"})
 
-    wg.Add(1)
-    jsonBlob = []byte(`{
+	wg.Add(1)
+	jsonBlob = []byte(`{
         "storeId": "testStore",
         "responseType": "updateStoreResponse",
         "itemId": "id1",
         "storeVersion": 55
     }`)
-    bus.SendResponseMessage("sync-channel", jsonBlob, nil)
+	bus.SendResponseMessage("sync-channel", jsonBlob, nil)
 
-    bus.SendResponseMessage("sync-channel", []byte(`{
+	bus.SendResponseMessage("sync-channel", []byte(`{
         "storeId": "testStore",
         "responseType": "updateStoreResponse",
         "itemId": "id1",
@@ -618,25 +616,25 @@ func TestBusStore_GalacticStoreUpdates(t *testing.T) {
         "storeVersion": 55
     }`), nil)
 
-    wg.Wait()
+	wg.Wait()
 
-    assert.Equal(t, lastStoreChange.Id, "id1")
-    assert.Equal(t, lastStoreChange.Value, MockStoreItem{From: "admin", Message:"value1"})
-    assert.Equal(t, lastStoreChange.IsDeleteChange, true)
-    assert.Nil(t, store.GetValue("id1"))
+	assert.Equal(t, lastStoreChange.Id, "id1")
+	assert.Equal(t, lastStoreChange.Value, MockStoreItem{From: "admin", Message: "value1"})
+	assert.Equal(t, lastStoreChange.IsDeleteChange, true)
+	assert.Nil(t, store.GetValue("id1"))
 }
 
 func TestBusStore_GalacticStoreContent(t *testing.T) {
-    store, _, bus := testGalacticStore(reflect.TypeOf(MockStoreItem{}))
+	store, _, bus := testGalacticStore(reflect.TypeOf(MockStoreItem{}))
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    store.WhenReady(func() {
-        wg.Done()
-    })
+	store.WhenReady(func() {
+		wg.Done()
+	})
 
-    var jsonBlob = []byte(`{
+	var jsonBlob = []byte(`{
         "storeId": "testStore",
         "responseType": "storeContentResponse",
         "items": {
@@ -646,13 +644,13 @@ func TestBusStore_GalacticStoreContent(t *testing.T) {
         },
         "storeVersion": 12
     }`)
-    bus.SendResponseMessage("sync-channel", jsonBlob, nil)
+	bus.SendResponseMessage("sync-channel", jsonBlob, nil)
 
-    wg.Wait()
+	wg.Wait()
 
-    allValues, version := store.AllValuesAndVersion()
-    assert.Equal(t, version, int64(12))
-    assert.Equal(t, len(allValues), 2)
-    assert.Equal(t, allValues["id1"], MockStoreItem{From: "admin", Message:"value1"})
-    assert.Equal(t, allValues["id2"], MockStoreItem{From: "admin", Message:"value2"})
+	allValues, version := store.AllValuesAndVersion()
+	assert.Equal(t, version, int64(12))
+	assert.Equal(t, len(allValues), 2)
+	assert.Equal(t, allValues["id1"], MockStoreItem{From: "admin", Message: "value1"})
+	assert.Equal(t, allValues["id2"], MockStoreItem{From: "admin", Message: "value2"})
 }

--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,3 @@ require (
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 )
-
-replace github.com/go-stomp/stomp/v3 => /Users/dshanley/Projects/go-stomp

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/eliukblau/pixterm v1.3.1
 	github.com/fatih/color v1.12.0
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/go-stomp/stomp v2.1.4+incompatible
+	github.com/go-stomp/stomp/v3 v3.0.3
 	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.4.2
@@ -29,3 +29,5 @@ require (
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 )
+
+replace github.com/go-stomp/stomp/v3 => /Users/dshanley/Projects/go-stomp

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/go-stomp/stomp v2.1.4+incompatible h1:D3SheUVDOz9RsjVWkoh/1iCOwD0qWjy
 github.com/go-stomp/stomp v2.1.4+incompatible/go.mod h1:VqCtqNZv1226A1/79yh+rMiFUcfY3R109np+7ke4n0c=
 github.com/go-stomp/stomp/v3 v3.0.2 h1:Y+6IDI7LSosjUgPWxo5ruRVEEDL5JKTBkfuf5tUpGgA=
 github.com/go-stomp/stomp/v3 v3.0.2/go.mod h1:jTrybHBK20jPdM9iyh65m6GusX6aMf7atfEFZ1nIcgc=
+github.com/go-stomp/stomp/v3 v3.0.3 h1:7YQGJCDMkbA05Rw8dS00LxwU1mhzEHS69gMlPjMZGDk=
+github.com/go-stomp/stomp/v3 v3.0.3/go.mod h1:jTrybHBK20jPdM9iyh65m6GusX6aMf7atfEFZ1nIcgc=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stomp/stomp v2.1.4+incompatible h1:D3SheUVDOz9RsjVWkoh/1iCOwD0qWjyeTZMUZ0EXg2Y=
 github.com/go-stomp/stomp v2.1.4+incompatible/go.mod h1:VqCtqNZv1226A1/79yh+rMiFUcfY3R109np+7ke4n0c=
+github.com/go-stomp/stomp/v3 v3.0.2 h1:Y+6IDI7LSosjUgPWxo5ruRVEEDL5JKTBkfuf5tUpGgA=
+github.com/go-stomp/stomp/v3 v3.0.2/go.mod h1:jTrybHBK20jPdM9iyh65m6GusX6aMf7atfEFZ1nIcgc=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -325,8 +327,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
-github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/model/message_factory.go
+++ b/model/message_factory.go
@@ -6,52 +6,54 @@ package model
 import "github.com/google/uuid"
 
 type MessageConfig struct {
-    Id            *uuid.UUID
-    DestinationId *uuid.UUID
-    Destination   string
-    Channel       string
-    Payload       interface{}
-    Headers       []MessageHeader
-    Direction     Direction
-    Err           error
+	Id            *uuid.UUID
+	DestinationId *uuid.UUID
+	Destination   string
+	Channel       string
+	Payload       interface{}
+	Headers       []MessageHeader
+	Direction     Direction
+	Err           error
 }
 
 func checkId(msgConfig *MessageConfig) {
-    if msgConfig.Id == nil {
-        id := uuid.New()
-        msgConfig.Id = &id
-    }
+	if msgConfig.Id == nil {
+		id := uuid.New()
+		msgConfig.Id = &id
+	}
 }
 
 func GenerateRequest(msgConfig *MessageConfig) *Message {
-    checkId(msgConfig)
-    return &Message{
-        Id:            msgConfig.Id,
-        Channel:       msgConfig.Channel,
-        DestinationId: msgConfig.DestinationId,
-        Destination:   msgConfig.Destination,
-        Payload:       msgConfig.Payload,
-        Direction:     RequestDir}
+	checkId(msgConfig)
+	return &Message{
+		Headers:       msgConfig.Headers,
+		Id:            msgConfig.Id,
+		Channel:       msgConfig.Channel,
+		DestinationId: msgConfig.DestinationId,
+		Destination:   msgConfig.Destination,
+		Payload:       msgConfig.Payload,
+		Direction:     RequestDir}
 }
 
 func GenerateResponse(msgConfig *MessageConfig) *Message {
-    checkId(msgConfig)
-    return &Message{
-        Id:            msgConfig.Id,
-        Channel:       msgConfig.Channel,
-        DestinationId: msgConfig.DestinationId,
-        Destination:   msgConfig.Destination,
-        Payload:       msgConfig.Payload,
-        Direction:     ResponseDir}
+	checkId(msgConfig)
+	return &Message{
+		Headers:       msgConfig.Headers,
+		Id:            msgConfig.Id,
+		Channel:       msgConfig.Channel,
+		DestinationId: msgConfig.DestinationId,
+		Destination:   msgConfig.Destination,
+		Payload:       msgConfig.Payload,
+		Direction:     ResponseDir}
 }
 
 func GenerateError(msgConfig *MessageConfig) *Message {
-    checkId(msgConfig)
-    return &Message{
-        Id:            msgConfig.Id,
-        Channel:       msgConfig.Channel,
-        DestinationId: msgConfig.DestinationId,
-        Destination:   msgConfig.Destination,
-        Error:         msgConfig.Err,
-        Direction:     ErrorDir}
+	checkId(msgConfig)
+	return &Message{
+		Id:            msgConfig.Id,
+		Channel:       msgConfig.Channel,
+		DestinationId: msgConfig.DestinationId,
+		Destination:   msgConfig.Destination,
+		Error:         msgConfig.Err,
+		Direction:     ErrorDir}
 }

--- a/model/request.go
+++ b/model/request.go
@@ -44,9 +44,9 @@ func CreateServiceRequestWithValues(requestType string, vals url.Values) Request
 		Payload: vals}
 }
 
-// CreateServiceRequestWithPointer does the same as CreateServiceRequest, except the payload is a pointer to the
+// CreateServiceRequestWithHttpRequest does the same as CreateServiceRequest, except the payload is a pointer to the
 // Incoming http.Request, so you can essentially extract what ever you want from the incoming request within your service.
-func CreateServiceRequestWithPointer(requestType string, r *http.Request) Request {
+func CreateServiceRequestWithHttpRequest(requestType string, r *http.Request) Request {
 	id := uuid.New()
 	return Request{
 		Id:      &id,

--- a/model/request.go
+++ b/model/request.go
@@ -3,19 +3,53 @@
 
 package model
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	"net/http"
+	"net/url"
+)
 
 type Request struct {
-    Id                *uuid.UUID               `json:"id"`
-    Created           int64                    `json:"created"`
-    Version           int                      `json:"version"`
-    Destination       string                   `json:"channel"`
-    Payload           interface{}              `json:"payload"`
-    Request           string                   `json:"request"`
-    // Populated if the request was sent on a "private" channel and
-    // indicates where to send back the Response.
-    // A service should check this field and if not null copy it to the
-    // Response.BrokerDestination field to ensure that the response will be sent
-    // back on the correct the "private" channel.
-    BrokerDestination *BrokerDestinationConfig `json:"-"`
+	Id          *uuid.UUID  `json:"id"`
+	Created     int64       `json:"created"`
+	Version     int         `json:"version"`
+	Destination string      `json:"channel"`
+	Payload     interface{} `json:"payload"`
+	Request     string      `json:"request"`
+	// Populated if the request was sent on a "private" channel and
+	// indicates where to send back the Response.
+	// A service should check this field and if not null copy it to the
+	// Response.BrokerDestination field to ensure that the response will be sent
+	// back on the correct the "private" channel.
+	BrokerDestination *BrokerDestinationConfig `json:"-"`
+}
+
+// CreateServiceRequest is a small utility function that takes request type and payload and
+// returns a new model.Request instance populated with them
+func CreateServiceRequest(requestType string, body []byte) Request {
+	id := uuid.New()
+	return Request{
+		Id:      &id,
+		Request: requestType,
+		Payload: body}
+}
+
+// CreateServiceRequestWithValues does the same as CreateServiceRequest, except the payload is url.Values and not
+// A byte[] array
+func CreateServiceRequestWithValues(requestType string, vals url.Values) Request {
+	id := uuid.New()
+	return Request{
+		Id:      &id,
+		Request: requestType,
+		Payload: vals}
+}
+
+// CreateServiceRequestWithPointer does the same as CreateServiceRequest, except the payload is a pointer to the
+// Incoming http.Request, so you can essentially extract what ever you want from the incoming request within your service.
+func CreateServiceRequestWithPointer(requestType string, r *http.Request) Request {
+	id := uuid.New()
+	return Request{
+		Id:      &id,
+		Request: requestType,
+		Payload: r}
 }

--- a/plank/pkg/server/core_models.go
+++ b/plank/pkg/server/core_models.go
@@ -55,9 +55,11 @@ type PlatformServer interface {
 	RegisterService(svc service.FabricService, svcChannel string) error         // register a new service at given channel
 	SetHttpChannelBridge(bridgeConfig *service.RESTBridgeConfig)                // set up a REST bridge for a service
 	SetStaticRoute(prefix, fullpath string, middlewareFn ...mux.MiddlewareFunc) // set up a static content route
+	SetHttpPathPrefixChannelBridge(bridgeConfig *service.RESTBridgeConfig)      // set up a REST bridge for a path prefix for a service.
 	CustomizeTLSConfig(tls *tls.Config) error                                   // used to replace default tls.Config for HTTP server with a custom config
 	GetRestBridgeSubRoute(uri, method string) (*mux.Route, error)               // get *mux.Route that maps to the provided uri and method
 	GetMiddlewareManager() middleware.MiddlewareManager                         // get middleware manager
+
 }
 
 // platformServer is the main struct that holds all components together including servers, various managers etc.
@@ -76,10 +78,10 @@ type platformServer struct {
 	lock                         sync.Mutex                        // lock
 }
 
-// transportChannelResponse wraps Transport *message.Message with an error object for easier transfer
-type transportChannelResponse struct {
-	message *model.Message // wrapper object that contains the payload
-	err     error          // error object if there is any
+// TransportChannelResponse wraps Transport *Message.Message with an error object for easier transfer
+type TransportChannelResponse struct {
+	Message *model.Message // wrapper object that contains the payload
+	Err     error          // error object if there is any
 }
 
 // ServerAvailability contains boolean fields to indicate what components of the system are available or not

--- a/plank/pkg/server/initialize.go
+++ b/plank/pkg/server/initialize.go
@@ -110,7 +110,7 @@ func (ps *platformServer) initialize() {
 		if val, found := svcReadyStore.Get(request.ServiceChannel); !found || !val.(bool) {
 			readyChan := hooks.OnServiceReady()
 			svcReadyStore.Put(request.ServiceChannel, <-readyChan, service.ServiceInitStateChange)
-			utils.Log.Infof("Service '%s' initialized successfully", reflect.TypeOf(fabricSvc).String())
+			utils.Log.Infof("[plank] Service '%s' initialized successfully", reflect.TypeOf(fabricSvc).String())
 			close(readyChan)
 		}
 
@@ -153,7 +153,7 @@ func (ps *platformServer) configureFabric() {
 	}
 
 	var err error
-	utils.Log.Infof("Starting Fabric broker at %s:%d%s",
+	utils.Log.Infof("[plank] Starting Transport broker at %s:%d%s",
 		ps.serverConfig.Host, ps.serverConfig.Port, ps.serverConfig.FabricConfig.FabricEndpoint)
 
 	// TODO: consider tightening access by allowing configuring allowedOrigins

--- a/plank/services/ping-pong-service.go
+++ b/plank/services/ping-pong-service.go
@@ -104,7 +104,7 @@ func (ps *PingPongService) GetRESTBridgeConfig() []*service.RESTBridgeConfig {
 			AllowOptions:   true,
 			FabricRequestBuilder: func(w http.ResponseWriter, r *http.Request) model.Request {
 				body, _ := ioutil.ReadAll(r.Body)
-				return createServiceRequest("ping-post", body)
+				return model.CreateServiceRequest("ping-post", body)
 			},
 		},
 		{
@@ -134,14 +134,4 @@ func (ps *PingPongService) GetRESTBridgeConfig() []*service.RESTBridgeConfig {
 			},
 		},
 	}
-}
-
-// createServiceRequest is a small utility function that takes request type and payload and
-// returns a new model.Request instance populated with them
-func createServiceRequest(requestType string, body []byte) model.Request {
-	id := uuid.New()
-	return model.Request{
-		Id:      &id,
-		Request: requestType,
-		Payload: body}
 }

--- a/plank/test_utils/test_suite_harness.go
+++ b/plank/test_utils/test_suite_harness.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 package test_utils
 
 import (
@@ -33,7 +36,7 @@ type PlankIntegrationTestSuite struct {
 }
 
 // PlankIntegrationTest allows test suites that use PlankIntegrationTestSuite as an embedded struct to set everything
-// we need on our test.
+// we need on our test. This is the only contract required to use this harness.
 type PlankIntegrationTest interface {
 	SetPlatformServer(server.PlatformServer)
 	SetSysChan(chan os.Signal)
@@ -49,6 +52,8 @@ func SetupPlankTestSuiteForTest(suite *PlankIntegrationTestSuite, test PlankInte
 	test.SetBus(suite.EventBus)
 }
 
+// SetupPlankTestSuite will boot a new instance of plank on your chosen port and will also fire up your service
+// Ready to be tested. This always runs on localhost.
 func SetupPlankTestSuite(service service.FabricService, serviceChannel string, port int) (*PlankIntegrationTestSuite, error) {
 
 	s := &PlankIntegrationTestSuite{}

--- a/plank/test_utils/test_suite_harness.go
+++ b/plank/test_utils/test_suite_harness.go
@@ -1,0 +1,100 @@
+package test_utils
+
+import (
+	"errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"github.com/vmware/transport-go/bus"
+	"github.com/vmware/transport-go/plank/pkg/server"
+	"github.com/vmware/transport-go/plank/utils"
+	"github.com/vmware/transport-go/service"
+	"os"
+	"time"
+)
+
+// PlankIntegrationTestSuite makes it easy to set up integration tests for services, that use plank and transport
+// In a realistic manner. This is a convenience mechanism to avoid having to rig this harnessing up yourself.
+type PlankIntegrationTestSuite struct {
+
+	// suite.Suite is a reference to a testify test suite.
+	suite.Suite
+
+	// server.PlatformServer is a reference to plank
+	server.PlatformServer
+
+	// os.Signal is the signal channel passed into plan for OS level notifications.
+	Syschan chan os.Signal
+
+	// bus.ChannelManager is a reference to the Transport's Channel Manager.
+	bus.ChannelManager
+
+	// bus.EventBus is a reference to Transport.
+	bus.EventBus
+}
+
+// PlankIntegrationTest allows test suites that use PlankIntegrationTestSuite as an embedded struct to set everything
+// we need on our test.
+type PlankIntegrationTest interface {
+	SetPlatformServer(server.PlatformServer)
+	SetSysChan(chan os.Signal)
+	SetChannelManager(bus.ChannelManager)
+	SetBus(eventBus bus.EventBus)
+}
+
+// SetupPlankTestSuiteForTest will copy over everything from the newly set up test suite, to a suite being run.
+func SetupPlankTestSuiteForTest(suite *PlankIntegrationTestSuite, test PlankIntegrationTest) {
+	test.SetPlatformServer(suite.PlatformServer)
+	test.SetSysChan(suite.Syschan)
+	test.SetChannelManager(suite.ChannelManager)
+	test.SetBus(suite.EventBus)
+}
+
+func SetupPlankTestSuite(service service.FabricService, serviceChannel string, port int) (*PlankIntegrationTestSuite, error) {
+
+	s := &PlankIntegrationTestSuite{}
+
+	customFormatter := new(logrus.TextFormatter)
+	utils.Log.SetFormatter(customFormatter)
+	customFormatter.DisableTimestamp = true
+
+	// instantiate a server config
+	serverConfig := &server.PlatformServerConfig{
+		Host:                       "localhost",
+		NoBanner:                   true,
+		Port:                       port,
+		RootDir:                    "/",
+		StaticDir:                  []string{"/static"},
+		RestBridgeTimeoutInMinutes: 30 * time.Second,
+		ShutdownTimeoutInMinutes:   1,
+		LogConfig: &utils.LogConfig{
+			OutputLog:     "stdout",
+			AccessLog:     "stdout",
+			ErrorLog:      "stderr",
+			FormatOptions: &utils.LogFormatOption{DisableTimestamp: true},
+		},
+	}
+
+	s.PlatformServer = server.NewPlatformServer(serverConfig)
+	if err := s.PlatformServer.RegisterService(service, serviceChannel); err != nil {
+		return nil, errors.New("cannot create printing press service, test failed")
+	}
+
+	s.Syschan = make(chan os.Signal, 1)
+	go s.PlatformServer.StartServer(s.Syschan)
+
+	s.EventBus = bus.GetBus()
+
+	// get a pointer to the channel manager
+	s.ChannelManager = s.EventBus.GetChannelManager()
+
+	// wait, service may be slow loading, rest mapping happens last.
+	wait := make(chan bool)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		wait <- true // Sending something to the channel to let the main thread continue
+
+	}()
+
+	<-wait
+	return s, nil
+}

--- a/plank/test_utils/test_suite_harness_test.go
+++ b/plank/test_utils/test_suite_harness_test.go
@@ -1,0 +1,66 @@
+package test_utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/vmware/transport-go/bus"
+	"github.com/vmware/transport-go/model"
+	"github.com/vmware/transport-go/plank/pkg/server"
+	"github.com/vmware/transport-go/service"
+	"os"
+	"testing"
+)
+
+func TestGetBasicTestServerConfig(t *testing.T) {
+	config := GetBasicTestServerConfig("/", "stdout", "stdout", "stderr", 999, true)
+	assert.Equal(t, "/", config.RootDir)
+	assert.Equal(t, 999, config.Port)
+}
+
+// define mock integration suite
+type testPlankTestIntegration struct {
+	PlankIntegrationTestSuite
+}
+
+func (m *testPlankTestIntegration) SetPlatformServer(s server.PlatformServer) {
+	m.PlatformServer = s
+}
+func (m *testPlankTestIntegration) SetSysChan(c chan os.Signal) {
+	m.Syschan = c
+}
+func (m *testPlankTestIntegration) SetChannelManager(cm bus.ChannelManager) {
+	m.ChannelManager = cm
+}
+func (m *testPlankTestIntegration) SetBus(eventBus bus.EventBus) {
+	m.EventBus = eventBus
+}
+
+func TestSetupPlankTestSuiteForTest(t *testing.T) {
+	b := bus.GetBus()
+	cm := b.GetChannelManager()
+	pit := &PlankIntegrationTestSuite{
+		Suite:          suite.Suite{},
+		PlatformServer: nil,
+		Syschan:        make(chan os.Signal),
+		ChannelManager: cm,
+		EventBus:       b,
+	}
+
+	test := &testPlankTestIntegration{}
+	SetupPlankTestSuiteForTest(pit, test)
+	assert.Equal(t, cm, test.ChannelManager)
+	assert.Equal(t, b, test.EventBus)
+	assert.Nil(t, nil, test.PlatformServer)
+}
+
+type testService struct {
+}
+
+func (t *testService) HandleServiceRequest(rt *model.Request, c service.FabricServiceCore) {
+}
+
+func TestSetupPlankTestSuite(t *testing.T) {
+	suite, err := SetupPlankTestSuite(&testService{}, "nowhere", 62986, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, suite)
+}

--- a/stompserver/raw_connection.go
+++ b/stompserver/raw_connection.go
@@ -4,24 +4,24 @@
 package stompserver
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "time"
+	"github.com/go-stomp/stomp/v3/frame"
+	"time"
 )
 
 type RawConnection interface {
-    // Reads a single frame object
-    ReadFrame() (*frame.Frame, error)
-    // Sends a single frame object
-    WriteFrame(frame *frame.Frame) error
-    // Set deadline for reading frames
-    SetReadDeadline(t time.Time)
-    // Close the connection
-    Close() error
+	// Reads a single frame object
+	ReadFrame() (*frame.Frame, error)
+	// Sends a single frame object
+	WriteFrame(frame *frame.Frame) error
+	// Set deadline for reading frames
+	SetReadDeadline(t time.Time)
+	// Close the connection
+	Close() error
 }
 
 type RawConnectionListener interface {
-    // Blocks until a new RawConnection is established.
-    Accept() (RawConnection, error)
-    // Stops the connection listener.
-    Close() error
+	// Blocks until a new RawConnection is established.
+	Accept() (RawConnection, error)
+	// Stops the connection listener.
+	Close() error
 }

--- a/stompserver/server.go
+++ b/stompserver/server.go
@@ -4,10 +4,10 @@
 package stompserver
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "log"
-    "strconv"
-    "sync"
+	"github.com/go-stomp/stomp/v3/frame"
+	"log"
+	"strconv"
+	"sync"
 )
 
 type SubscribeHandlerFunction func(conId string, subId string, destination string, frame *frame.Frame)
@@ -17,330 +17,332 @@ type UnsubscribeHandlerFunction func(conId string, subId string, destination str
 type ApplicationRequestHandlerFunction func(destination string, message []byte, connectionId string)
 
 type StompServer interface {
-    // starts the server
-    Start()
-    // stops the server
-    Stop()
-    // sends a message to a given stomp topic destination
-    SendMessage(destination string, messageBody []byte)
-    // sends a message to a single connection client
-    SendMessageToClient(connectionId string, destination string, messageBody []byte)
-    // registers a callback for stomp subscribe events
-    OnSubscribeEvent(callback SubscribeHandlerFunction)
-    // registers a callback for stomp unsubscribe events
-    OnUnsubscribeEvent(callback UnsubscribeHandlerFunction)
-    // registers a callback for application requests
-    OnApplicationRequest(callback ApplicationRequestHandlerFunction)
-    // SetConnectionEventCallback is used to set up a callback when certain STOMP session events happen
-    // such as ConnectionStarting, ConnectionClosed, SubscribeToTopic, UnsubscribeFromTopic and IncomingMessage.
-    SetConnectionEventCallback(connEventType StompSessionEventType, cb func(connEvent *ConnEvent))
+	// starts the server
+	Start()
+	// stops the server
+	Stop()
+	// sends a message to a given stomp topic destination
+	SendMessage(destination string, messageBody []byte)
+	// sends a message to a single connection client
+	SendMessageToClient(connectionId string, destination string, messageBody []byte)
+	// registers a callback for stomp subscribe events
+	OnSubscribeEvent(callback SubscribeHandlerFunction)
+	// registers a callback for stomp unsubscribe events
+	OnUnsubscribeEvent(callback UnsubscribeHandlerFunction)
+	// registers a callback for application requests
+	OnApplicationRequest(callback ApplicationRequestHandlerFunction)
+	// SetConnectionEventCallback is used to set up a callback when certain STOMP session events happen
+	// such as ConnectionStarting, ConnectionClosed, SubscribeToTopic, UnsubscribeFromTopic and IncomingMessage.
+	SetConnectionEventCallback(connEventType StompSessionEventType, cb func(connEvent *ConnEvent))
 }
 
 type StompSessionEventType int
+
 const (
-    ConnectionStarting StompSessionEventType = iota
-    ConnectionEstablished
-    ConnectionClosed
-    SubscribeToTopic
-    UnsubscribeFromTopic
-    IncomingMessage
+	ConnectionStarting StompSessionEventType = iota
+	ConnectionEstablished
+	ConnectionClosed
+	SubscribeToTopic
+	UnsubscribeFromTopic
+	IncomingMessage
 )
 
 type ConnEvent struct {
-    ConnId    string
-    eventType StompSessionEventType
-    conn      StompConn
-    destination string
-    sub *subscription
-    frame *frame.Frame
+	ConnId      string
+	eventType   StompSessionEventType
+	conn        StompConn
+	destination string
+	sub         *subscription
+	frame       *frame.Frame
 }
 
 type apiEventType int
+
 const (
-    closeServer apiEventType = iota
-    sendMessage
-    sendPrivateMessage
+	closeServer apiEventType = iota
+	sendMessage
+	sendPrivateMessage
 )
 
 type apiEvent struct {
-    eventType   apiEventType
-    connId      string
-    frame       *frame.Frame
-    destination string
+	eventType   apiEventType
+	connId      string
+	frame       *frame.Frame
+	destination string
 }
 
 type connSubscriptions struct {
-    conn StompConn
-    subscriptions map[string]*subscription
+	conn          StompConn
+	subscriptions map[string]*subscription
 }
 
-func newConnSubscriptions(conn StompConn) *connSubscriptions{
-    return &connSubscriptions{
-        conn: conn,
-        subscriptions: make(map[string]*subscription),
-    }
+func newConnSubscriptions(conn StompConn) *connSubscriptions {
+	return &connSubscriptions{
+		conn:          conn,
+		subscriptions: make(map[string]*subscription),
+	}
 }
 
 type stompServer struct {
-    connectionListener RawConnectionListener
-    connectionEvents chan *ConnEvent
-    connectionEventCallbacks map[StompSessionEventType]func(event *ConnEvent)
-    apiEvents chan *apiEvent
-    running bool
-    connectionsMap map[string]StompConn
-    subscriptionsMap map[string] map[string]*connSubscriptions
-    config StompConfig
-    callbackLock sync.RWMutex
-    subscribeCallbacks []SubscribeHandlerFunction
-    unsubscribeCallbacks []UnsubscribeHandlerFunction
-    applicationRequestCallbacks []ApplicationRequestHandlerFunction
+	connectionListener          RawConnectionListener
+	connectionEvents            chan *ConnEvent
+	connectionEventCallbacks    map[StompSessionEventType]func(event *ConnEvent)
+	apiEvents                   chan *apiEvent
+	running                     bool
+	connectionsMap              map[string]StompConn
+	subscriptionsMap            map[string]map[string]*connSubscriptions
+	config                      StompConfig
+	callbackLock                sync.RWMutex
+	subscribeCallbacks          []SubscribeHandlerFunction
+	unsubscribeCallbacks        []UnsubscribeHandlerFunction
+	applicationRequestCallbacks []ApplicationRequestHandlerFunction
 }
 
 func NewStompServer(listener RawConnectionListener, config StompConfig) StompServer {
-    server := &stompServer{
-        config:                      config,
-        connectionListener:          listener,
-        apiEvents:                   make(chan *apiEvent, 32),
-        connectionsMap:              make(map[string]StompConn),
-        connectionEvents:            make(chan *ConnEvent, 64),
-        connectionEventCallbacks:    make(map[StompSessionEventType]func(event *ConnEvent)),
-        subscriptionsMap:            make(map[string]map[string]*connSubscriptions),
-        subscribeCallbacks:          make([]SubscribeHandlerFunction, 0),
-        unsubscribeCallbacks:        make([]UnsubscribeHandlerFunction, 0),
-        applicationRequestCallbacks: make([]ApplicationRequestHandlerFunction, 0),
-    }
+	server := &stompServer{
+		config:                      config,
+		connectionListener:          listener,
+		apiEvents:                   make(chan *apiEvent, 32),
+		connectionsMap:              make(map[string]StompConn),
+		connectionEvents:            make(chan *ConnEvent, 64),
+		connectionEventCallbacks:    make(map[StompSessionEventType]func(event *ConnEvent)),
+		subscriptionsMap:            make(map[string]map[string]*connSubscriptions),
+		subscribeCallbacks:          make([]SubscribeHandlerFunction, 0),
+		unsubscribeCallbacks:        make([]UnsubscribeHandlerFunction, 0),
+		applicationRequestCallbacks: make([]ApplicationRequestHandlerFunction, 0),
+	}
 
-    return server
+	return server
 }
 
 func (s *stompServer) OnSubscribeEvent(callback SubscribeHandlerFunction) {
-    s.callbackLock.Lock()
-    defer s.callbackLock.Unlock()
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 
-    s.subscribeCallbacks = append(s.subscribeCallbacks, callback)
+	s.subscribeCallbacks = append(s.subscribeCallbacks, callback)
 }
 
 func (s *stompServer) OnUnsubscribeEvent(callback UnsubscribeHandlerFunction) {
-    s.callbackLock.Lock()
-    defer s.callbackLock.Unlock()
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 
-    s.unsubscribeCallbacks = append(s.unsubscribeCallbacks, callback)
+	s.unsubscribeCallbacks = append(s.unsubscribeCallbacks, callback)
 }
 
 func (s *stompServer) OnApplicationRequest(callback ApplicationRequestHandlerFunction) {
-    s.callbackLock.Lock()
-    defer s.callbackLock.Unlock()
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
 
-    s.applicationRequestCallbacks = append(s.applicationRequestCallbacks, callback)
+	s.applicationRequestCallbacks = append(s.applicationRequestCallbacks, callback)
 }
 
 func (s *stompServer) SendMessage(destination string, messageBody []byte) {
 
-    // create send frame.
-    f := frame.New(frame.MESSAGE,
-        frame.Destination, destination,
-        frame.ContentLength, strconv.Itoa(len(messageBody)),
-        frame.ContentType, "application/json;charset=UTF-8")
+	// create send frame.
+	f := frame.New(frame.MESSAGE,
+		frame.Destination, destination,
+		frame.ContentLength, strconv.Itoa(len(messageBody)),
+		frame.ContentType, "application/json;charset=UTF-8")
 
-    f.Body = messageBody
+	f.Body = messageBody
 
-    s.apiEvents <- &apiEvent{
-        eventType: sendMessage,
-        destination: destination,
-        frame: f,
-    }
+	s.apiEvents <- &apiEvent{
+		eventType:   sendMessage,
+		destination: destination,
+		frame:       f,
+	}
 }
 
 func (s *stompServer) SendMessageToClient(connectionId string, destination string, messageBody []byte) {
 
-    // create send frame.
-    f := frame.New(frame.MESSAGE,
-        frame.Destination, destination,
-        frame.ContentLength, strconv.Itoa(len(messageBody)),
-        frame.ContentType, "application/json;charset=UTF-8")
+	// create send frame.
+	f := frame.New(frame.MESSAGE,
+		frame.Destination, destination,
+		frame.ContentLength, strconv.Itoa(len(messageBody)),
+		frame.ContentType, "application/json;charset=UTF-8")
 
-    f.Body = messageBody
+	f.Body = messageBody
 
-    s.apiEvents <- &apiEvent{
-        eventType: sendPrivateMessage,
-        destination: destination,
-        frame: f,
-        connId: connectionId,
-    }
+	s.apiEvents <- &apiEvent{
+		eventType:   sendPrivateMessage,
+		destination: destination,
+		frame:       f,
+		connId:      connectionId,
+	}
 }
 
 func (s *stompServer) SetConnectionEventCallback(connEventType StompSessionEventType, cb func(connEvent *ConnEvent)) {
-    s.callbackLock.Lock()
-    defer s.callbackLock.Unlock()
-    s.connectionEventCallbacks[connEventType] = cb
+	s.callbackLock.Lock()
+	defer s.callbackLock.Unlock()
+	s.connectionEventCallbacks[connEventType] = cb
 }
 
 func (s *stompServer) Start() {
-    if s.running {
-        return
-    }
+	if s.running {
+		return
+	}
 
-    s.running = true
-    go s.waitForConnections()
-    s.run()
+	s.running = true
+	go s.waitForConnections()
+	s.run()
 }
 
 func (s *stompServer) Stop() {
-    if s.running {
-        s.running = false
-        s.apiEvents <- &apiEvent{
-            eventType: closeServer,
-        }
-    }
+	if s.running {
+		s.running = false
+		s.apiEvents <- &apiEvent{
+			eventType: closeServer,
+		}
+	}
 }
 
 func (s *stompServer) waitForConnections() {
-    for {
-         rawConn, err :=  s.connectionListener.Accept()
-         if err != nil {
-             log.Println("Failed to establish client connection:", err)
-         } else {
-             c := NewStompConn(rawConn, s.config, s.connectionEvents)
+	for {
+		rawConn, err := s.connectionListener.Accept()
+		if err != nil {
+			log.Println("Failed to establish client connection:", err)
+		} else {
+			c := NewStompConn(rawConn, s.config, s.connectionEvents)
 
-             s.connectionEvents <- &ConnEvent{
-                 ConnId:    c.GetId(),
-                 conn:      c,
-                 eventType: ConnectionStarting,
-             }
-         }
-    }
+			s.connectionEvents <- &ConnEvent{
+				ConnId:    c.GetId(),
+				conn:      c,
+				eventType: ConnectionStarting,
+			}
+		}
+	}
 }
 
 func (s *stompServer) run() {
-    for {
-        select {
+	for {
+		select {
 
-        case apiEvent, _ := <- s.apiEvents:
-            if apiEvent.eventType == closeServer {
-                s.connectionListener.Close()
-                // close all open connections
-                for _, c := range s.connectionsMap {
-                    c.Close()
-                }
-                s.connectionsMap = make(map[string]StompConn)
-                return
-            } else if apiEvent.eventType == sendMessage {
-                s.sendFrame(apiEvent.destination, apiEvent.frame)
-            } else if apiEvent.eventType == sendPrivateMessage {
-                s.sendFrameToClient(apiEvent.connId, apiEvent.destination, apiEvent.frame)
-            }
+		case apiEvent, _ := <-s.apiEvents:
+			if apiEvent.eventType == closeServer {
+				s.connectionListener.Close()
+				// close all open connections
+				for _, c := range s.connectionsMap {
+					c.Close()
+				}
+				s.connectionsMap = make(map[string]StompConn)
+				return
+			} else if apiEvent.eventType == sendMessage {
+				s.sendFrame(apiEvent.destination, apiEvent.frame)
+			} else if apiEvent.eventType == sendPrivateMessage {
+				s.sendFrameToClient(apiEvent.connId, apiEvent.destination, apiEvent.frame)
+			}
 
-        case e, _ := <- s.connectionEvents:
-            s.handleConnectionEvent(e)
-        }
-    }
+		case e, _ := <-s.connectionEvents:
+			s.handleConnectionEvent(e)
+		}
+	}
 }
 
 func (s *stompServer) handleConnectionEvent(e *ConnEvent) {
 
-    s.callbackLock.RLock()
-    defer s.callbackLock.RUnlock()
+	s.callbackLock.RLock()
+	defer s.callbackLock.RUnlock()
 
-    switch e.eventType {
-    case ConnectionStarting:
-        s.connectionsMap[e.conn.GetId()] = e.conn
-        if fn, exists := s.connectionEventCallbacks[ConnectionStarting]; exists {
-            fn(e)
-        }
+	switch e.eventType {
+	case ConnectionStarting:
+		s.connectionsMap[e.conn.GetId()] = e.conn
+		if fn, exists := s.connectionEventCallbacks[ConnectionStarting]; exists {
+			fn(e)
+		}
 
-    case ConnectionClosed:
-        delete(s.connectionsMap, e.conn.GetId())
-        for _, connSubscriptions := range s.subscriptionsMap {
-            conSub, ok := connSubscriptions[e.conn.GetId()]
-            if ok {
-                delete(connSubscriptions, e.conn.GetId())
-                for _, sub := range conSub.subscriptions {
-                    for _, callback := range s.unsubscribeCallbacks {
-                        callback(e.conn.GetId(), sub.id, sub.destination)
-                    }
-                }
-            }
-        }
-        if fn, exists := s.connectionEventCallbacks[ConnectionClosed]; exists {
-            fn(e)
-        }
+	case ConnectionClosed:
+		delete(s.connectionsMap, e.conn.GetId())
+		for _, connSubscriptions := range s.subscriptionsMap {
+			conSub, ok := connSubscriptions[e.conn.GetId()]
+			if ok {
+				delete(connSubscriptions, e.conn.GetId())
+				for _, sub := range conSub.subscriptions {
+					for _, callback := range s.unsubscribeCallbacks {
+						callback(e.conn.GetId(), sub.id, sub.destination)
+					}
+				}
+			}
+		}
+		if fn, exists := s.connectionEventCallbacks[ConnectionClosed]; exists {
+			fn(e)
+		}
 
-    case SubscribeToTopic:
-        subsMap, ok := s.subscriptionsMap[e.destination]
-        if !ok {
-            subsMap = make(map[string]*connSubscriptions)
-            s.subscriptionsMap[e.destination] = subsMap
-        }
-        var conSub *connSubscriptions
-        conSub, ok = subsMap[e.conn.GetId()]
-        if !ok {
-            conSub = newConnSubscriptions(e.conn)
-            subsMap[e.conn.GetId()] = conSub
-        }
-        conSub.subscriptions[e.sub.id] = e.sub
+	case SubscribeToTopic:
+		subsMap, ok := s.subscriptionsMap[e.destination]
+		if !ok {
+			subsMap = make(map[string]*connSubscriptions)
+			s.subscriptionsMap[e.destination] = subsMap
+		}
+		var conSub *connSubscriptions
+		conSub, ok = subsMap[e.conn.GetId()]
+		if !ok {
+			conSub = newConnSubscriptions(e.conn)
+			subsMap[e.conn.GetId()] = conSub
+		}
+		conSub.subscriptions[e.sub.id] = e.sub
 
-        // notify listeners
-        for _, callback := range s.subscribeCallbacks {
-            callback(e.conn.GetId(), e.sub.id, e.destination, e.frame)
-        }
-        if fn, exists := s.connectionEventCallbacks[SubscribeToTopic]; exists {
-            fn(e)
-        }
+		// notify listeners
+		for _, callback := range s.subscribeCallbacks {
+			callback(e.conn.GetId(), e.sub.id, e.destination, e.frame)
+		}
+		if fn, exists := s.connectionEventCallbacks[SubscribeToTopic]; exists {
+			fn(e)
+		}
 
-    case UnsubscribeFromTopic:
-        subs, ok := s.subscriptionsMap[e.destination]
-        if ok {
-            var conSub *connSubscriptions
-            conSub, ok = subs[e.conn.GetId()]
-            if ok {
-                _, ok = conSub.subscriptions[e.sub.id]
-                if ok {
-                    delete(conSub.subscriptions, e.sub.id)
-                    // notify listeners
-                    for _, callback := range s.unsubscribeCallbacks {
-                        callback(e.conn.GetId(), e.sub.id, e.destination)
-                    }
-                }
-            }
-        }
-        if fn, exists := s.connectionEventCallbacks[UnsubscribeFromTopic]; exists {
-            fn(e)
-        }
+	case UnsubscribeFromTopic:
+		subs, ok := s.subscriptionsMap[e.destination]
+		if ok {
+			var conSub *connSubscriptions
+			conSub, ok = subs[e.conn.GetId()]
+			if ok {
+				_, ok = conSub.subscriptions[e.sub.id]
+				if ok {
+					delete(conSub.subscriptions, e.sub.id)
+					// notify listeners
+					for _, callback := range s.unsubscribeCallbacks {
+						callback(e.conn.GetId(), e.sub.id, e.destination)
+					}
+				}
+			}
+		}
+		if fn, exists := s.connectionEventCallbacks[UnsubscribeFromTopic]; exists {
+			fn(e)
+		}
 
-    case IncomingMessage:
-        s.sendFrame(e.destination, e.frame)
+	case IncomingMessage:
+		s.sendFrame(e.destination, e.frame)
 
-        if s.config.IsAppRequestDestination(e.destination) && e.conn != nil {
-            // notify app listeners
-            for _, callback := range s.applicationRequestCallbacks {
-                callback(e.destination, e.frame.Body, e.conn.GetId())
-            }
-        }
-        if fn, exists := s.connectionEventCallbacks[IncomingMessage]; exists {
-            fn(e)
-        }
-    }
+		if s.config.IsAppRequestDestination(e.destination) && e.conn != nil {
+			// notify app listeners
+			for _, callback := range s.applicationRequestCallbacks {
+				callback(e.destination, e.frame.Body, e.conn.GetId())
+			}
+		}
+		if fn, exists := s.connectionEventCallbacks[IncomingMessage]; exists {
+			fn(e)
+		}
+	}
 }
 
 func (s *stompServer) sendFrame(dest string, f *frame.Frame) {
-    subsMap, ok := s.subscriptionsMap[dest]
-    if ok {
-        for _, connSub := range subsMap {
-            for _, sub := range connSub.subscriptions {
-                connSub.conn.SendFrameToSubscription(f.Clone(), sub)
-            }
-        }
-    }
+	subsMap, ok := s.subscriptionsMap[dest]
+	if ok {
+		for _, connSub := range subsMap {
+			for _, sub := range connSub.subscriptions {
+				connSub.conn.SendFrameToSubscription(f.Clone(), sub)
+			}
+		}
+	}
 }
 
 func (s *stompServer) sendFrameToClient(conId string, dest string, f *frame.Frame) {
-    subsMap, ok := s.subscriptionsMap[dest]
-    if ok {
-        connSubscriptions, ok := subsMap[conId]
-        if ok {
-            for _, sub := range connSubscriptions.subscriptions {
-                connSubscriptions.conn.SendFrameToSubscription(f.Clone(), sub)
-            }
-        }
-    }
+	subsMap, ok := s.subscriptionsMap[dest]
+	if ok {
+		connSubscriptions, ok := subsMap[conId]
+		if ok {
+			for _, sub := range connSubscriptions.subscriptions {
+				connSubscriptions.conn.SendFrameToSubscription(f.Clone(), sub)
+			}
+		}
+	}
 }

--- a/stompserver/server_test.go
+++ b/stompserver/server_test.go
@@ -4,527 +4,524 @@
 package stompserver
 
 import (
-    "errors"
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/stretchr/testify/assert"
-    "strconv"
-    "sync"
-    "testing"
+	"errors"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"sync"
+	"testing"
 )
 
 type MockRawConnectionListener struct {
-    connected bool
-    incomingConnections chan interface{}
+	connected           bool
+	incomingConnections chan interface{}
 }
 
 func NewMockRawConnectionListener() *MockRawConnectionListener {
-    return &MockRawConnectionListener{
-       incomingConnections: make(chan interface{}),
-       connected: true,
-    }
+	return &MockRawConnectionListener{
+		incomingConnections: make(chan interface{}),
+		connected:           true,
+	}
 }
 
 func (cl *MockRawConnectionListener) Accept() (RawConnection, error) {
-    obj := <- cl.incomingConnections
-    mockConn, ok := obj.(*MockRawConnection)
-    if ok {
-        return mockConn, nil
-    }
+	obj := <-cl.incomingConnections
+	mockConn, ok := obj.(*MockRawConnection)
+	if ok {
+		return mockConn, nil
+	}
 
-    return nil, obj.(error)
+	return nil, obj.(error)
 }
 
 func (cl *MockRawConnectionListener) Close() error {
-    cl.connected = false
-    return nil
+	cl.connected = false
+	return nil
 }
 
 func newTestStompServer(config StompConfig) (*stompServer, *MockRawConnectionListener) {
-    listener := NewMockRawConnectionListener()
-    return NewStompServer(listener, config).(*stompServer), listener
+	listener := NewMockRawConnectionListener()
+	return NewStompServer(listener, config).(*stompServer), listener
 
 }
 
 func TestStompServer_NewSubscription(t *testing.T) {
-    server, conListener := newTestStompServer(NewStompConfig(0, []string {"/pub"}))
+	server, conListener := newTestStompServer(NewStompConfig(0, []string{"/pub"}))
 
-    go server.Start()
+	go server.Start()
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    server.OnSubscribeEvent(
-        func(conId string, subId string, destination string, frame *frame.Frame) {
-            assert.Equal(t, subId, "sub-id-1")
-            wg.Done()
-        })
+	server.OnSubscribeEvent(
+		func(conId string, subId string, destination string, frame *frame.Frame) {
+			assert.Equal(t, subId, "sub-id-1")
+			wg.Done()
+		})
 
-    mockRawConn := NewMockRawConnection()
-    conListener.incomingConnections <- mockRawConn
+	mockRawConn := NewMockRawConnection()
+	conListener.incomingConnections <- mockRawConn
 
-    mockRawConn.SendConnectFrame()
-    mockRawConn.incomingFrames <- frame.New(frame.SUBSCRIBE,
-        frame.Destination, "/topic/destination",
-        frame.Id, "sub-id-1")
+	mockRawConn.SendConnectFrame()
+	mockRawConn.incomingFrames <- frame.New(frame.SUBSCRIBE,
+		frame.Destination, "/topic/destination",
+		frame.Id, "sub-id-1")
 
-    wg.Wait()
+	wg.Wait()
 }
 
 func TestStompServer_OnApplicationRequest(t *testing.T) {
-    appPrefixes := []string{"/pub", "/pub2", "/pub3/"}
-    server, _ := newTestStompServer(NewStompConfig(0, appPrefixes))
+	appPrefixes := []string{"/pub", "/pub2", "/pub3/"}
+	server, _ := newTestStompServer(NewStompConfig(0, appPrefixes))
 
-    assert.Equal(t, server.config.AppDestinationPrefix(), []string{"/pub/", "/pub2/", "/pub3/"})
-    assert.Equal(t, appPrefixes, []string{"/pub", "/pub2", "/pub3/"})
-    fmt.Println(appPrefixes)
+	assert.Equal(t, server.config.AppDestinationPrefix(), []string{"/pub/", "/pub2/", "/pub3/"})
+	assert.Equal(t, appPrefixes, []string{"/pub", "/pub2", "/pub3/"})
+	fmt.Println(appPrefixes)
 
-    go server.Start()
+	go server.Start()
 
-    wg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 
-    wg.Add(2)
-    server.OnApplicationRequest(func(destination string, message []byte, connectionId string) {
-        if destination == "/pub/testRequest1" {
-            assert.Equal(t, string(message), "request1-payload")
-            assert.Equal(t, connectionId, "con1")
-            wg.Done()
-        } else if destination == "/pub2/testRequest2" {
-            assert.Equal(t, string(message), "request2-payload")
-            assert.Equal(t, connectionId, "con2")
-            wg.Done()
-        } else {
-            assert.Fail(t, "unexpected request")
-        }
-    })
+	wg.Add(2)
+	server.OnApplicationRequest(func(destination string, message []byte, connectionId string) {
+		if destination == "/pub/testRequest1" {
+			assert.Equal(t, string(message), "request1-payload")
+			assert.Equal(t, connectionId, "con1")
+			wg.Done()
+		} else if destination == "/pub2/testRequest2" {
+			assert.Equal(t, string(message), "request2-payload")
+			assert.Equal(t, connectionId, "con2")
+			wg.Done()
+		} else {
+			assert.Fail(t, "unexpected request")
+		}
+	})
 
-    f1 := frame.New(frame.MESSAGE, frame.Destination, "/pub/testRequest1")
-    f1.Body = []byte("request1-payload")
+	f1 := frame.New(frame.MESSAGE, frame.Destination, "/pub/testRequest1")
+	f1.Body = []byte("request1-payload")
 
-    f2 := frame.New(frame.MESSAGE, frame.Destination, "/pub2/testRequest2")
-    f2.Body = []byte("request2-payload")
+	f2 := frame.New(frame.MESSAGE, frame.Destination, "/pub2/testRequest2")
+	f2.Body = []byte("request2-payload")
 
-    server.connectionEvents <- &ConnEvent{
-        ConnId:    "con1",
-        eventType: IncomingMessage,
-        conn: &stompConn{
-            id: "con1",
-        },
-        destination: "/pub/testRequest1",
-        frame: f1,
-    }
-    server.connectionEvents <- &ConnEvent{
-        ConnId: "con2",
-        eventType: IncomingMessage,
-        conn: &stompConn{
-            id: "con2",
-        },
-        destination: "/pub2/testRequest2",
-        frame: f2,
-    }
-    server.connectionEvents <- &ConnEvent{
-        ConnId: "con1",
-        eventType: IncomingMessage,
-        conn: &stompConn{
-            id: "con1",
-        },
-        destination: "/pub4/testRequest3",
-        frame: frame.New(frame.MESSAGE, frame.Destination, "/pub3/testRequest3"),
-    }
+	server.connectionEvents <- &ConnEvent{
+		ConnId:    "con1",
+		eventType: IncomingMessage,
+		conn: &stompConn{
+			id: "con1",
+		},
+		destination: "/pub/testRequest1",
+		frame:       f1,
+	}
+	server.connectionEvents <- &ConnEvent{
+		ConnId:    "con2",
+		eventType: IncomingMessage,
+		conn: &stompConn{
+			id: "con2",
+		},
+		destination: "/pub2/testRequest2",
+		frame:       f2,
+	}
+	server.connectionEvents <- &ConnEvent{
+		ConnId:    "con1",
+		eventType: IncomingMessage,
+		conn: &stompConn{
+			id: "con1",
+		},
+		destination: "/pub4/testRequest3",
+		frame:       frame.New(frame.MESSAGE, frame.Destination, "/pub3/testRequest3"),
+	}
 
-    wg.Wait()
+	wg.Wait()
 }
 
 func TestStompServer_SendMessage(t *testing.T) {
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    go server.Start()
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    mockRwConn2 := NewMockRawConnection()
-    mockRwConn3 := NewMockRawConnection()
+	mockRwConn1 := NewMockRawConnection()
+	mockRwConn2 := NewMockRawConnection()
+	mockRwConn3 := NewMockRawConnection()
 
-    listener.incomingConnections <- mockRwConn1
-    listener.incomingConnections <- mockRwConn2
-    listener.incomingConnections <- mockRwConn3
+	listener.incomingConnections <- mockRwConn1
+	listener.incomingConnections <- mockRwConn2
+	listener.incomingConnections <- mockRwConn3
 
-    mockRwConn1.SendConnectFrame()
-    mockRwConn2.SendConnectFrame()
-    mockRwConn3.SendConnectFrame()
+	mockRwConn1.SendConnectFrame()
+	mockRwConn2.SendConnectFrame()
+	mockRwConn3.SendConnectFrame()
 
-    wg := sync.WaitGroup{}
-    wg.Add(6)
-    server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	wg.Add(6)
+	server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
+		wg.Done()
+	})
 
-    subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1", "/topic/test-topic1", "/topic/test-topic2")
-    subscribeMockConToTopic(mockRwConn2, "/topic/test-topic1", "/topic/test-topic3")
-    subscribeMockConToTopic(mockRwConn3, "/topic/test-topic3")
+	subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1", "/topic/test-topic1", "/topic/test-topic2")
+	subscribeMockConToTopic(mockRwConn2, "/topic/test-topic1", "/topic/test-topic3")
+	subscribeMockConToTopic(mockRwConn3, "/topic/test-topic3")
 
-    wg.Wait()
+	wg.Wait()
 
-    mockRwConn1.writeWg = &wg
-    mockRwConn2.writeWg = &wg
-    mockRwConn3.writeWg = &wg
+	mockRwConn1.writeWg = &wg
+	mockRwConn2.writeWg = &wg
+	mockRwConn3.writeWg = &wg
 
-    wg.Add(3)
-    server.SendMessage("/topic/test-topic1", []byte("test-message"))
-    wg.Wait()
+	wg.Add(3)
+	server.SendMessage("/topic/test-topic1", []byte("test-message"))
+	wg.Wait()
 
-    f := mockRwConn1.LastSentFrame()
-    assert.Equal(t, len(mockRwConn1.sentFrames), 3)
-    verifyFrame(t, f, frame.New(
-        frame.MESSAGE, frame.Destination, "/topic/test-topic1"), false)
-    assert.Equal(t, string(f.Body), "test-message")
+	f := mockRwConn1.LastSentFrame()
+	assert.Equal(t, len(mockRwConn1.sentFrames), 3)
+	verifyFrame(t, f, frame.New(
+		frame.MESSAGE, frame.Destination, "/topic/test-topic1"), false)
+	assert.Equal(t, string(f.Body), "test-message")
 
-    f = mockRwConn2.LastSentFrame()
-    assert.Equal(t, len(mockRwConn2.sentFrames), 2)
-    verifyFrame(t, f, frame.New(frame.MESSAGE,
-            frame.Destination, "/topic/test-topic1",
-            frame.Subscription, "/topic/test-topic1-0"), false)
-    assert.Equal(t, string(f.Body), "test-message")
+	f = mockRwConn2.LastSentFrame()
+	assert.Equal(t, len(mockRwConn2.sentFrames), 2)
+	verifyFrame(t, f, frame.New(frame.MESSAGE,
+		frame.Destination, "/topic/test-topic1",
+		frame.Subscription, "/topic/test-topic1-0"), false)
+	assert.Equal(t, string(f.Body), "test-message")
 
-    assert.Equal(t, len(mockRwConn3.sentFrames), 1)
+	assert.Equal(t, len(mockRwConn3.sentFrames), 1)
 
-    wg.Add(2)
-    server.SendMessage("/topic/test-topic3", []byte("test-message2"))
-    wg.Wait()
+	wg.Add(2)
+	server.SendMessage("/topic/test-topic3", []byte("test-message2"))
+	wg.Wait()
 
-    assert.Equal(t, len(mockRwConn1.sentFrames), 3)
+	assert.Equal(t, len(mockRwConn1.sentFrames), 3)
 
-    assert.Equal(t, len(mockRwConn2.sentFrames), 3)
-    assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message2")
+	assert.Equal(t, len(mockRwConn2.sentFrames), 3)
+	assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message2")
 
-    assert.Equal(t, len(mockRwConn3.sentFrames), 2)
-    assert.Equal(t, string(mockRwConn3.LastSentFrame().Body), "test-message2")
+	assert.Equal(t, len(mockRwConn3.sentFrames), 2)
+	assert.Equal(t, string(mockRwConn3.LastSentFrame().Body), "test-message2")
 
-    wg.Add(1)
-    server.SendMessage("/topic/test-topic2", []byte("test-message3"))
-    wg.Wait()
+	wg.Add(1)
+	server.SendMessage("/topic/test-topic2", []byte("test-message3"))
+	wg.Wait()
 
-    assert.Equal(t, len(mockRwConn1.sentFrames), 4)
-    assert.Equal(t, string(mockRwConn1.LastSentFrame().Body), "test-message3")
-    assert.Equal(t, len(mockRwConn2.sentFrames), 3)
-    assert.Equal(t, len(mockRwConn3.sentFrames), 2)
+	assert.Equal(t, len(mockRwConn1.sentFrames), 4)
+	assert.Equal(t, string(mockRwConn1.LastSentFrame().Body), "test-message3")
+	assert.Equal(t, len(mockRwConn2.sentFrames), 3)
+	assert.Equal(t, len(mockRwConn3.sentFrames), 2)
 
+	server.OnUnsubscribeEvent(func(conId string, subId string, destination string) {
+		wg.Done()
+	})
 
-    server.OnUnsubscribeEvent(func(conId string, subId string, destination string) {
-        wg.Done()
-    })
+	wg.Add(1)
+	mockRwConn1.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-0")
+	wg.Wait()
 
-    wg.Add(1)
-    mockRwConn1.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-0")
-    wg.Wait()
+	wg.Add(2)
+	server.SendMessage("/topic/test-topic1", []byte("test-message4"))
+	wg.Wait()
 
+	assert.Equal(t, len(mockRwConn1.sentFrames), 5)
+	assert.Equal(t, string(mockRwConn1.LastSentFrame().Body), "test-message4")
+	assert.Equal(t, len(mockRwConn2.sentFrames), 4)
+	assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message4")
 
-    wg.Add(2)
-    server.SendMessage("/topic/test-topic1", []byte("test-message4"))
-    wg.Wait()
+	wg.Add(1)
+	mockRwConn1.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-1")
+	wg.Wait()
 
-    assert.Equal(t, len(mockRwConn1.sentFrames), 5)
-    assert.Equal(t, string(mockRwConn1.LastSentFrame().Body), "test-message4")
-    assert.Equal(t, len(mockRwConn2.sentFrames), 4)
-    assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message4")
+	wg.Add(1)
+	server.SendMessage("/topic/test-topic1", []byte("test-message5"))
+	wg.Wait()
 
-    wg.Add(1)
-    mockRwConn1.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-1")
-    wg.Wait()
+	assert.Equal(t, len(mockRwConn1.sentFrames), 5)
+	assert.Equal(t, len(mockRwConn2.sentFrames), 5)
+	assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message5")
+	assert.Equal(t, len(mockRwConn3.sentFrames), 2)
 
-    wg.Add(1)
-    server.SendMessage("/topic/test-topic1", []byte("test-message5"))
-    wg.Wait()
+	wg.Add(2)
+	mockRwConn2.incomingFrames <- frame.New(frame.DISCONNECT)
+	wg.Wait()
 
-    assert.Equal(t, len(mockRwConn1.sentFrames), 5)
-    assert.Equal(t, len(mockRwConn2.sentFrames), 5)
-    assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message5")
-    assert.Equal(t, len(mockRwConn3.sentFrames), 2)
+	wg.Add(1)
+	server.SendMessage("/topic/test-topic3", []byte("test-message6"))
+	wg.Wait()
 
-    wg.Add(2)
-    mockRwConn2.incomingFrames <- frame.New(frame.DISCONNECT)
-    wg.Wait()
+	assert.Equal(t, len(mockRwConn1.sentFrames), 5)
+	assert.Equal(t, len(mockRwConn2.sentFrames), 5)
+	assert.Equal(t, len(mockRwConn3.sentFrames), 3)
+	assert.Equal(t, string(mockRwConn3.LastSentFrame().Body), "test-message6")
 
-    wg.Add(1)
-    server.SendMessage("/topic/test-topic3", []byte("test-message6"))
-    wg.Wait()
-
-    assert.Equal(t, len(mockRwConn1.sentFrames), 5)
-    assert.Equal(t, len(mockRwConn2.sentFrames), 5)
-    assert.Equal(t, len(mockRwConn3.sentFrames), 3)
-    assert.Equal(t, string(mockRwConn3.LastSentFrame().Body), "test-message6")
-
-    wg.Add(2)
-    server.OnUnsubscribeEvent(func(conId string, subId string, destination string) {
-        assert.Equal(t, subId, "/topic/test-topic3-0")
-        assert.Equal(t, destination, "/topic/test-topic3")
-        wg.Done()
-    })
-    mockRwConn3.incomingFrames <- frame.New(frame.DISCONNECT)
-    wg.Wait()
+	wg.Add(2)
+	server.OnUnsubscribeEvent(func(conId string, subId string, destination string) {
+		assert.Equal(t, subId, "/topic/test-topic3-0")
+		assert.Equal(t, destination, "/topic/test-topic3")
+		wg.Done()
+	})
+	mockRwConn3.incomingFrames <- frame.New(frame.DISCONNECT)
+	wg.Wait()
 }
 
 func TestStompServer_SetConnectionEventCallback_ConnectionStarting(t *testing.T) {
-    wg := sync.WaitGroup{}
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    server.SetConnectionEventCallback(ConnectionStarting, func(connEvent *ConnEvent) {
-        assert.Equal(t, ConnectionStarting, connEvent.eventType)
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	server.SetConnectionEventCallback(ConnectionStarting, func(connEvent *ConnEvent) {
+		assert.Equal(t, ConnectionStarting, connEvent.eventType)
+		wg.Done()
+	})
 
-    go server.Start()
+	go server.Start()
 
-    wg.Add(1)
-    mockRwConn1 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
+	wg.Add(1)
+	mockRwConn1 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
 
-    // should trigger ConnectionStarting callback
-    mockRwConn1.SendConnectFrame()
-    wg.Wait()
+	// should trigger ConnectionStarting callback
+	mockRwConn1.SendConnectFrame()
+	wg.Wait()
 }
 
 func TestStompServer_SetConnectionEventCallback_SubscribeToTopic(t *testing.T) {
-    wg := sync.WaitGroup{}
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    server.SetConnectionEventCallback(SubscribeToTopic, func(connEvent *ConnEvent) {
-        assert.Equal(t, SubscribeToTopic, connEvent.eventType)
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	server.SetConnectionEventCallback(SubscribeToTopic, func(connEvent *ConnEvent) {
+		assert.Equal(t, SubscribeToTopic, connEvent.eventType)
+		wg.Done()
+	})
 
-    go server.Start()
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
+	mockRwConn1 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
 
-    // connect first
-    mockRwConn1.SendConnectFrame()
+	// connect first
+	mockRwConn1.SendConnectFrame()
 
-    // should trigger SubscribeToTopic callback
-    wg.Add(1)
-    subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
-    wg.Wait()
+	// should trigger SubscribeToTopic callback
+	wg.Add(1)
+	subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
+	wg.Wait()
 }
 
 func TestStompServer_SetConnectionEventCallback_IncomingMessage(t *testing.T) {
-    wg := sync.WaitGroup{}
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    server.SetConnectionEventCallback(IncomingMessage, func(connEvent *ConnEvent) {
-        assert.Equal(t, IncomingMessage, connEvent.eventType)
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	server.SetConnectionEventCallback(IncomingMessage, func(connEvent *ConnEvent) {
+		assert.Equal(t, IncomingMessage, connEvent.eventType)
+		wg.Done()
+	})
 
-    go server.Start()
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
+	mockRwConn1 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
 
-    // connect first
-    mockRwConn1.SendConnectFrame()
+	// connect first
+	mockRwConn1.SendConnectFrame()
 
-    // only decerement wg after subscription has been established
-    server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
-        wg.Done()
-    })
+	// only decerement wg after subscription has been established
+	server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
+		wg.Done()
+	})
 
-    // subscribe to a topic
-    wg.Add(1)
-    subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
-    wg.Wait()
+	// subscribe to a topic
+	wg.Add(1)
+	subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
+	wg.Wait()
 
-    // should trigger IncomingMessage callback
-    wg.Add(1)
-    server.connectionEvents <- &ConnEvent{
-        ConnId: "con1",
-        eventType: IncomingMessage,
-        conn: &stompConn{
-            id: "con1",
-        },
-        destination: "/pub/test-topic1",
-        frame: frame.New(frame.SEND),
-    }
-    wg.Wait()
+	// should trigger IncomingMessage callback
+	wg.Add(1)
+	server.connectionEvents <- &ConnEvent{
+		ConnId:    "con1",
+		eventType: IncomingMessage,
+		conn: &stompConn{
+			id: "con1",
+		},
+		destination: "/pub/test-topic1",
+		frame:       frame.New(frame.SEND),
+	}
+	wg.Wait()
 }
 
 func TestStompServer_SetConnectionEventCallback_Unsubscribe(t *testing.T) {
-    wg := sync.WaitGroup{}
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    server.SetConnectionEventCallback(UnsubscribeFromTopic, func(connEvent *ConnEvent) {
-        assert.Equal(t, UnsubscribeFromTopic, connEvent.eventType)
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	server.SetConnectionEventCallback(UnsubscribeFromTopic, func(connEvent *ConnEvent) {
+		assert.Equal(t, UnsubscribeFromTopic, connEvent.eventType)
+		wg.Done()
+	})
 
-    go server.Start()
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
+	mockRwConn1 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
 
-    // should trigger ConnectionStarting callback
-    mockRwConn1.SendConnectFrame()
+	// should trigger ConnectionStarting callback
+	mockRwConn1.SendConnectFrame()
 
-    server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
-        wg.Done()
-    })
+	server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
+		wg.Done()
+	})
 
-    // subscribe to a channel
-    wg.Add(1)
-    subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
+	// subscribe to a channel
+	wg.Add(1)
+	subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1")
 
-    // should trigger UnsubscribeFromTopic callback
-    wg.Add(1)
-    mockRwConn1.incomingFrames <- frame.New(frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-0")
-    wg.Wait()
+	// should trigger UnsubscribeFromTopic callback
+	wg.Add(1)
+	mockRwConn1.incomingFrames <- frame.New(frame.UNSUBSCRIBE, frame.Id, "/topic/test-topic1-0")
+	wg.Wait()
 }
 
 func TestStompServer_SetConnectionEventCallback_Disconnect(t *testing.T) {
-    wg := sync.WaitGroup{}
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    server.SetConnectionEventCallback(ConnectionClosed, func(connEvent *ConnEvent) {
-        assert.Equal(t, ConnectionClosed, connEvent.eventType)
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	server.SetConnectionEventCallback(ConnectionClosed, func(connEvent *ConnEvent) {
+		assert.Equal(t, ConnectionClosed, connEvent.eventType)
+		wg.Done()
+	})
 
-    go server.Start()
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
+	mockRwConn1 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
 
-    // connect
-    mockRwConn1.SendConnectFrame()
+	// connect
+	mockRwConn1.SendConnectFrame()
 
-    // should trigger ConnectionClosed callback
-    wg.Add(1)
-    mockRwConn1.incomingFrames <- frame.New(frame.DISCONNECT)
-    wg.Wait()
+	// should trigger ConnectionClosed callback
+	wg.Add(1)
+	mockRwConn1.incomingFrames <- frame.New(frame.DISCONNECT)
+	wg.Wait()
 }
 
 func TestStompServer_SendMessageToClient(t *testing.T) {
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
-    go server.Start()
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub/"}))
+	go server.Start()
 
-    mockRwConn1 := NewMockRawConnection()
-    mockRwConn2 := NewMockRawConnection()
+	mockRwConn1 := NewMockRawConnection()
+	mockRwConn2 := NewMockRawConnection()
 
-    listener.incomingConnections <- mockRwConn1
-    listener.incomingConnections <- mockRwConn2
+	listener.incomingConnections <- mockRwConn1
+	listener.incomingConnections <- mockRwConn2
 
-    mockRwConn1.SendConnectFrame()
-    mockRwConn2.SendConnectFrame()
+	mockRwConn1.SendConnectFrame()
+	mockRwConn2.SendConnectFrame()
 
-    wg := sync.WaitGroup{}
-    wg.Add(5)
-    server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
-        wg.Done()
-    })
+	wg := sync.WaitGroup{}
+	wg.Add(5)
+	server.OnSubscribeEvent(func(conId string, subId string, destination string, f *frame.Frame) {
+		wg.Done()
+	})
 
-    subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1", "/topic/test-topic1", "/topic/test-topic2")
-    subscribeMockConToTopic(mockRwConn2, "/topic/test-topic1", "/topic/test-topic3")
+	subscribeMockConToTopic(mockRwConn1, "/topic/test-topic1", "/topic/test-topic1", "/topic/test-topic2")
+	subscribeMockConToTopic(mockRwConn2, "/topic/test-topic1", "/topic/test-topic3")
 
-    wg.Wait()
+	wg.Wait()
 
-    connMap := make(map[*MockRawConnection]*stompConn)
-    for _, conn := range server.connectionsMap {
-        if conn.(*stompConn).rawConnection == mockRwConn1 {
-            connMap[mockRwConn1] = conn.(*stompConn)
-        } else if conn.(*stompConn).rawConnection == mockRwConn2 {
-            connMap[mockRwConn2] = conn.(*stompConn)
-        }
-    }
+	connMap := make(map[*MockRawConnection]*stompConn)
+	for _, conn := range server.connectionsMap {
+		if conn.(*stompConn).rawConnection == mockRwConn1 {
+			connMap[mockRwConn1] = conn.(*stompConn)
+		} else if conn.(*stompConn).rawConnection == mockRwConn2 {
+			connMap[mockRwConn2] = conn.(*stompConn)
+		}
+	}
 
-    mockRwConn1.writeWg = &wg
-    mockRwConn2.writeWg = &wg
+	mockRwConn1.writeWg = &wg
+	mockRwConn2.writeWg = &wg
 
-    wg.Add(2)
-    server.SendMessageToClient(connMap[mockRwConn1].id, "/topic/test-topic1", []byte("test-message"))
-    wg.Wait()
+	wg.Add(2)
+	server.SendMessageToClient(connMap[mockRwConn1].id, "/topic/test-topic1", []byte("test-message"))
+	wg.Wait()
 
-    f := mockRwConn1.LastSentFrame()
-    assert.Equal(t, len(mockRwConn1.sentFrames), 3)
-    verifyFrame(t, f, frame.New(
-        frame.MESSAGE, frame.Destination, "/topic/test-topic1"), false)
-    assert.Equal(t, string(f.Body), "test-message")
+	f := mockRwConn1.LastSentFrame()
+	assert.Equal(t, len(mockRwConn1.sentFrames), 3)
+	verifyFrame(t, f, frame.New(
+		frame.MESSAGE, frame.Destination, "/topic/test-topic1"), false)
+	assert.Equal(t, string(f.Body), "test-message")
 
-    assert.Equal(t, len(mockRwConn2.sentFrames), 1)
+	assert.Equal(t, len(mockRwConn2.sentFrames), 1)
 
-    server.SendMessageToClient(connMap[mockRwConn2].id, "/topic/invalid-topic", []byte("invalid-message"))
+	server.SendMessageToClient(connMap[mockRwConn2].id, "/topic/invalid-topic", []byte("invalid-message"))
 
-    server.SendMessageToClient("invalid-connection-id", "/topic/invalid-topic", []byte("invalid-message"))
+	server.SendMessageToClient("invalid-connection-id", "/topic/invalid-topic", []byte("invalid-message"))
 
-    wg.Add(1)
-    server.SendMessageToClient(connMap[mockRwConn2].id, "/topic/test-topic1", []byte("test-message2"))
-    wg.Wait()
+	wg.Add(1)
+	server.SendMessageToClient(connMap[mockRwConn2].id, "/topic/test-topic1", []byte("test-message2"))
+	wg.Wait()
 
-    assert.Equal(t, len(mockRwConn1.sentFrames), 3)
-    assert.Equal(t, len(mockRwConn2.sentFrames), 2)
-    assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message2")
-
+	assert.Equal(t, len(mockRwConn1.sentFrames), 3)
+	assert.Equal(t, len(mockRwConn2.sentFrames), 2)
+	assert.Equal(t, string(mockRwConn2.LastSentFrame().Body), "test-message2")
 
 }
 
 func TestStompServer_Stop(t *testing.T) {
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub"}))
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub"}))
 
-    wg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 
-    go func() {
-        server.Start()
-        wg.Done()
-    }()
+	go func() {
+		server.Start()
+		wg.Done()
+	}()
 
-    mockRwConn1 := NewMockRawConnection()
-    mockRwConn2 := NewMockRawConnection()
-    listener.incomingConnections <- mockRwConn1
-    listener.incomingConnections <- mockRwConn2
+	mockRwConn1 := NewMockRawConnection()
+	mockRwConn2 := NewMockRawConnection()
+	listener.incomingConnections <- mockRwConn1
+	listener.incomingConnections <- mockRwConn2
 
-    wg.Add(2)
-    server.OnSubscribeEvent(func(conId string, subId string, destination string, frame *frame.Frame) {
-        wg.Done()
-    })
+	wg.Add(2)
+	server.OnSubscribeEvent(func(conId string, subId string, destination string, frame *frame.Frame) {
+		wg.Done()
+	})
 
-    mockRwConn1.SendConnectFrame()
-    mockRwConn2.SendConnectFrame()
-    subscribeMockConToTopic(mockRwConn1, "/topic1")
-    subscribeMockConToTopic(mockRwConn1, "/topic2")
+	mockRwConn1.SendConnectFrame()
+	mockRwConn2.SendConnectFrame()
+	subscribeMockConToTopic(mockRwConn1, "/topic1")
+	subscribeMockConToTopic(mockRwConn1, "/topic2")
 
-    wg.Wait()
+	wg.Wait()
 
-    // calling start on started server doesn't do anything and doesn't block
-    server.Start()
+	// calling start on started server doesn't do anything and doesn't block
+	server.Start()
 
-    wg.Add(1)
-    server.Stop()
-    wg.Wait()
+	wg.Add(1)
+	server.Stop()
+	wg.Wait()
 
-    assert.Equal(t, mockRwConn1.connected, false)
-    assert.Equal(t, mockRwConn2.connected, false)
-    assert.Equal(t, listener.connected, false)
+	assert.Equal(t, mockRwConn1.connected, false)
+	assert.Equal(t, mockRwConn2.connected, false)
+	assert.Equal(t, listener.connected, false)
 }
 
 func TestStompServer_ConnectionErrors(t *testing.T) {
-    server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub"}))
+	server, listener := newTestStompServer(NewStompConfig(0, []string{"/pub"}))
 
-    go server.Start()
+	go server.Start()
 
-    // simulate 10 errors
-    for i := 0; i < 10; i++ {
-        listener.incomingConnections <- errors.New("connection-error")
-    }
+	// simulate 10 errors
+	for i := 0; i < 10; i++ {
+		listener.incomingConnections <- errors.New("connection-error")
+	}
 
-    assert.Equal(t, len(server.connectionsMap), 0)
+	assert.Equal(t, len(server.connectionsMap), 0)
 
-    // verify that we can still connect after the errors
-    for i := 0; i < 5; i++ {
-        listener.incomingConnections <- NewMockRawConnection()
-    }
+	// verify that we can still connect after the errors
+	for i := 0; i < 5; i++ {
+		listener.incomingConnections <- NewMockRawConnection()
+	}
 
-    server.callbackLock.Lock()
-    defer server.callbackLock.Unlock()
-    assert.True(t, len(server.connectionsMap) > 0)
+	server.callbackLock.Lock()
+	defer server.callbackLock.Unlock()
+	assert.True(t, len(server.connectionsMap) > 0)
 }
 
 func subscribeMockConToTopic(conn *MockRawConnection, topics ...string) {
-    for index, topic := range topics {
-        conn.incomingFrames <- frame.New(frame.SUBSCRIBE,
-            frame.Destination, topic,
-            frame.Id, topic + "-" + strconv.Itoa(index))
-    }
+	for index, topic := range topics {
+		conn.incomingFrames <- frame.New(frame.SUBSCRIBE,
+			frame.Destination, topic,
+			frame.Id, topic+"-"+strconv.Itoa(index))
+	}
 }

--- a/stompserver/stomp_connection.go
+++ b/stompserver/stomp_connection.go
@@ -4,467 +4,465 @@
 package stompserver
 
 import (
-    "fmt"
-    "github.com/go-stomp/stomp"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/google/uuid"
-    "log"
-    "strconv"
-    "strings"
-    "sync"
-    "sync/atomic"
-    "time"
+	"fmt"
+	"github.com/go-stomp/stomp/v3"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/google/uuid"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type subscription struct {
-    id string
-    destination string
+	id          string
+	destination string
 }
 
 type StompConn interface {
-    // Return unique connection Id string
-    GetId() string
-    SendFrameToSubscription(f *frame.Frame, sub *subscription)
-    Close()
+	// Return unique connection Id string
+	GetId() string
+	SendFrameToSubscription(f *frame.Frame, sub *subscription)
+	Close()
 }
 
 const (
-    maxHeartBeatDuration = time.Duration(999999999) * time.Millisecond
+	maxHeartBeatDuration = time.Duration(999999999) * time.Millisecond
 )
 
 const (
-    connecting int32 = iota
-    connected
-    closed
+	connecting int32 = iota
+	connected
+	closed
 )
 
 type stompConn struct {
-    rawConnection    RawConnection
-    state            int32
-    version          stomp.Version
-    inFrames         chan *frame.Frame
-    outFrames        chan *frame.Frame
-    readTimeoutMs    int64
-    writeTimeout     time.Duration
-    id               string
-    events           chan *ConnEvent
-    config           StompConfig
-    subscriptions    map[string]*subscription
-    currentMessageId uint64
-    closeOnce        sync.Once
+	rawConnection    RawConnection
+	state            int32
+	version          stomp.Version
+	inFrames         chan *frame.Frame
+	outFrames        chan *frame.Frame
+	readTimeoutMs    int64
+	writeTimeout     time.Duration
+	id               string
+	events           chan *ConnEvent
+	config           StompConfig
+	subscriptions    map[string]*subscription
+	currentMessageId uint64
+	closeOnce        sync.Once
 }
 
 func NewStompConn(rawConnection RawConnection, config StompConfig, events chan *ConnEvent) StompConn {
-    conn := &stompConn{
-        rawConnection: rawConnection,
-        state:         connecting,
-        inFrames:      make(chan *frame.Frame, 32),
-        outFrames:     make(chan *frame.Frame, 32),
-        config:        config,
-        id:            uuid.New().String(),
-        events:        events,
-        subscriptions: make(map[string]*subscription),
-    }
+	conn := &stompConn{
+		rawConnection: rawConnection,
+		state:         connecting,
+		inFrames:      make(chan *frame.Frame, 32),
+		outFrames:     make(chan *frame.Frame, 32),
+		config:        config,
+		id:            uuid.New().String(),
+		events:        events,
+		subscriptions: make(map[string]*subscription),
+	}
 
-    go conn.run()
-    go conn.readInFrames()
+	go conn.run()
+	go conn.readInFrames()
 
-    return conn
+	return conn
 }
 
 func (conn *stompConn) SendFrameToSubscription(f *frame.Frame, sub *subscription) {
-    f.Header.Add(frame.Subscription, sub.id)
-    conn.outFrames <- f
+	f.Header.Add(frame.Subscription, sub.id)
+	conn.outFrames <- f
 }
 
 func (conn *stompConn) Close() {
-    conn.closeOnce.Do(func() {
-        atomic.StoreInt32(&conn.state, closed)
-        conn.rawConnection.Close()
+	conn.closeOnce.Do(func() {
+		atomic.StoreInt32(&conn.state, closed)
+		conn.rawConnection.Close()
 
-        conn.events <- &ConnEvent{
-            ConnId:    conn.GetId(),
-            eventType: ConnectionClosed,
-            conn:      conn,
-        }
-    })
+		conn.events <- &ConnEvent{
+			ConnId:    conn.GetId(),
+			eventType: ConnectionClosed,
+			conn:      conn,
+		}
+	})
 }
 
 func (conn *stompConn) GetId() string {
-    return conn.id
+	return conn.id
 }
 
 func (conn *stompConn) run() {
-    defer conn.Close()
+	defer conn.Close()
 
-    var timerChannel <-chan time.Time
-    var timer *time.Timer
+	var timerChannel <-chan time.Time
+	var timer *time.Timer
 
-    for {
+	for {
 
-        if atomic.LoadInt32(&conn.state) == closed {
-            return
-        }
+		if atomic.LoadInt32(&conn.state) == closed {
+			return
+		}
 
-        if timer == nil && conn.writeTimeout > 0 {
-            timer = time.NewTimer(conn.writeTimeout)
-            timerChannel = timer.C
-        }
+		if timer == nil && conn.writeTimeout > 0 {
+			timer = time.NewTimer(conn.writeTimeout)
+			timerChannel = timer.C
+		}
 
-        select {
-        case f, ok := <-conn.outFrames:
-            if !ok {
-                // close connection
-                return
-            }
+		select {
+		case f, ok := <-conn.outFrames:
+			if !ok {
+				// close connection
+				return
+			}
 
-            // reset heart-beat timer
-            if timer != nil {
-                timer.Stop()
-                timer = nil
-            }
+			// reset heart-beat timer
+			if timer != nil {
+				timer.Stop()
+				timer = nil
+			}
 
-            conn.populateMessageIdHeader(f)
+			conn.populateMessageIdHeader(f)
 
-            // write the frame to the client
-            err := conn.rawConnection.WriteFrame(f)
-            if err != nil || f.Command == frame.ERROR {
-                return
-            }
+			// write the frame to the client
+			err := conn.rawConnection.WriteFrame(f)
+			if err != nil || f.Command == frame.ERROR {
+				return
+			}
 
-        case f, ok := <-conn.inFrames:
-            if !ok {
-                return
-            }
+		case f, ok := <-conn.inFrames:
+			if !ok {
+				return
+			}
 
-            if err := conn.handleIncomingFrame(f); err != nil {
-                conn.sendError(err)
-                return
-            }
+			if err := conn.handleIncomingFrame(f); err != nil {
+				conn.sendError(err)
+				return
+			}
 
-
-        case _ = <-timerChannel:
-            // write a heart-beat
-            err := conn.rawConnection.WriteFrame(nil)
-            if err != nil {
-                return
-            }
-            if timer != nil {
-                timer.Stop()
-                timer = nil
-            }
-        }
-    }
+		case _ = <-timerChannel:
+			// write a heart-beat
+			err := conn.rawConnection.WriteFrame(nil)
+			if err != nil {
+				return
+			}
+			if timer != nil {
+				timer.Stop()
+				timer = nil
+			}
+		}
+	}
 }
 
 func (conn *stompConn) handleIncomingFrame(f *frame.Frame) error {
-    switch f.Command {
+	switch f.Command {
 
-    case frame.CONNECT, frame.STOMP:
-        return conn.handleConnect(f)
+	case frame.CONNECT, frame.STOMP:
+		return conn.handleConnect(f)
 
-    case frame.DISCONNECT:
-        return conn.handleDisconnect(f)
+	case frame.DISCONNECT:
+		return conn.handleDisconnect(f)
 
-    case frame.SEND:
-        return conn.handleSend(f)
+	case frame.SEND:
+		return conn.handleSend(f)
 
-    case frame.SUBSCRIBE:
-        return conn.handleSubscribe(f)
+	case frame.SUBSCRIBE:
+		return conn.handleSubscribe(f)
 
-    case frame.UNSUBSCRIBE:
-        return conn.handleUnsubscribe(f)
-    }
+	case frame.UNSUBSCRIBE:
+		return conn.handleUnsubscribe(f)
+	}
 
-    return unsupportedStompCommandError
+	return unsupportedStompCommandError
 }
 
 // Returns true if the frame contains ANY of the specified
 // headers
-func containsHeader(f *frame.Frame, headers... string) bool {
-    for _, h := range headers {
-        if _, ok := f.Header.Contains(h); ok {
-            return true
-        }
-    }
-    return false
+func containsHeader(f *frame.Frame, headers ...string) bool {
+	for _, h := range headers {
+		if _, ok := f.Header.Contains(h); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (conn *stompConn) handleConnect(f *frame.Frame) error {
-    if atomic.LoadInt32(&conn.state) == connected {
-        return unexpectedStompCommandError
-    }
+	if atomic.LoadInt32(&conn.state) == connected {
+		return unexpectedStompCommandError
+	}
 
-    if containsHeader(f, frame.Receipt) {
-        return invalidHeaderError
-    }
+	if containsHeader(f, frame.Receipt) {
+		return invalidHeaderError
+	}
 
+	var err error
+	conn.version, err = determineVersion(f)
+	if err != nil {
+		log.Println("cannot determine version")
+		return err
+	}
 
-    var err error
-    conn.version, err = determineVersion(f)
-    if err != nil {
-        log.Println("cannot determine version")
-        return err
-    }
+	if conn.version == stomp.V10 {
+		return unsupportedStompVersionError
+	}
 
-    if conn.version == stomp.V10 {
-        return unsupportedStompVersionError
-    }
+	cxDuration, cyDuration, err := getHeartBeat(f)
+	if err != nil {
+		log.Println("invalid heart-beat")
+		return err
+	}
 
-    cxDuration, cyDuration, err := getHeartBeat(f)
-    if err != nil {
-        log.Println("invalid heart-beat")
-        return err
-    }
+	min := time.Duration(conn.config.HeartBeat()) * time.Millisecond
+	if min > maxHeartBeatDuration {
+		min = maxHeartBeatDuration
+	}
 
-    min := time.Duration(conn.config.HeartBeat()) * time.Millisecond
-    if min > maxHeartBeatDuration {
-        min = maxHeartBeatDuration
-    }
+	// apply a minimum heartbeat
+	if cxDuration > 0 {
+		if min == 0 || cxDuration < min {
+			cxDuration = min
+		}
+	}
+	if cyDuration > 0 {
+		if min == 0 || cyDuration < min {
+			cyDuration = min
+		}
+	}
 
-    // apply a minimum heartbeat
-    if cxDuration > 0 {
-        if min == 0 || cxDuration < min {
-            cxDuration = min
-        }
-    }
-    if cyDuration > 0 {
-        if min == 0 || cyDuration < min {
-            cyDuration = min
-        }
-    }
+	conn.writeTimeout = cyDuration
 
-    conn.writeTimeout = cyDuration
+	cx, cy := int64(cxDuration/time.Millisecond), int64(cyDuration/time.Millisecond)
+	atomic.StoreInt64(&conn.readTimeoutMs, cx)
 
-    cx, cy := int64(cxDuration / time.Millisecond), int64(cyDuration / time.Millisecond)
-    atomic.StoreInt64(&conn.readTimeoutMs, cx)
+	response := frame.New(frame.CONNECTED,
+		frame.Version, string(conn.version),
+		frame.Server, "stompServer/0.0.1",
+		frame.HeartBeat, fmt.Sprintf("%d,%d", cy, cx))
 
-    response := frame.New(frame.CONNECTED,
-        frame.Version, string(conn.version),
-        frame.Server, "stompServer/0.0.1",
-        frame.HeartBeat, fmt.Sprintf("%d,%d", cy, cx))
+	err = conn.rawConnection.WriteFrame(response)
+	if err != nil {
+		return err
+	}
 
-    err = conn.rawConnection.WriteFrame(response)
-    if err != nil {
-        return err
-    }
+	atomic.StoreInt32(&conn.state, connected)
 
-    atomic.StoreInt32(&conn.state, connected)
+	conn.events <- &ConnEvent{
+		ConnId:    conn.GetId(),
+		eventType: ConnectionEstablished,
+		conn:      conn,
+	}
 
-    conn.events <- &ConnEvent{
-        ConnId:    conn.GetId(),
-        eventType: ConnectionEstablished,
-        conn:      conn,
-    }
-
-    return nil
+	return nil
 }
 
 func (conn *stompConn) handleDisconnect(f *frame.Frame) error {
-    if atomic.LoadInt32(&conn.state) == connecting {
-        return notConnectedStompError
-    }
+	if atomic.LoadInt32(&conn.state) == connecting {
+		return notConnectedStompError
+	}
 
-    conn.sendReceiptResponse(f)
-    conn.Close()
+	conn.sendReceiptResponse(f)
+	conn.Close()
 
-    return nil
+	return nil
 }
 
 func (conn *stompConn) handleSubscribe(f *frame.Frame) error {
-    switch atomic.LoadInt32(&conn.state) {
-    case connecting:
-        return notConnectedStompError
-    case closed:
-        return nil
-    }
+	switch atomic.LoadInt32(&conn.state) {
+	case connecting:
+		return notConnectedStompError
+	case closed:
+		return nil
+	}
 
-    subId, ok := f.Header.Contains(frame.Id)
-    if !ok {
-        return invalidSubscriptionError
-    }
+	subId, ok := f.Header.Contains(frame.Id)
+	if !ok {
+		return invalidSubscriptionError
+	}
 
-    dest, ok := f.Header.Contains(frame.Destination)
-    if !ok {
-        return invalidFrameError
-    }
+	dest, ok := f.Header.Contains(frame.Destination)
+	if !ok {
+		return invalidFrameError
+	}
 
-    if _, exists := conn.subscriptions[subId]; exists {
-        // subscription already exists
-        return nil
-    }
+	if _, exists := conn.subscriptions[subId]; exists {
+		// subscription already exists
+		return nil
+	}
 
-    conn.subscriptions[subId] = &subscription{
-        id: subId,
-        destination: dest,
-    }
+	conn.subscriptions[subId] = &subscription{
+		id:          subId,
+		destination: dest,
+	}
 
-    conn.events <- &ConnEvent{
-        ConnId:      conn.GetId(),
-        eventType:   SubscribeToTopic,
-        destination: dest,
-        conn:        conn,
-        sub:         conn.subscriptions[subId],
-        frame:       f,
-    }
+	conn.events <- &ConnEvent{
+		ConnId:      conn.GetId(),
+		eventType:   SubscribeToTopic,
+		destination: dest,
+		conn:        conn,
+		sub:         conn.subscriptions[subId],
+		frame:       f,
+	}
 
-    return nil
+	return nil
 }
 
 func (conn *stompConn) handleUnsubscribe(f *frame.Frame) error {
-    switch atomic.LoadInt32(&conn.state) {
-    case connecting:
-        return notConnectedStompError
-    case closed:
-        return nil
-    }
+	switch atomic.LoadInt32(&conn.state) {
+	case connecting:
+		return notConnectedStompError
+	case closed:
+		return nil
+	}
 
-    id, ok := f.Header.Contains(frame.Id)
-    if !ok {
-        return invalidSubscriptionError
-    }
+	id, ok := f.Header.Contains(frame.Id)
+	if !ok {
+		return invalidSubscriptionError
+	}
 
-    conn.sendReceiptResponse(f)
+	conn.sendReceiptResponse(f)
 
-    sub, ok := conn.subscriptions[id]
-    if !ok {
-        // subscription already removed
-        return nil
-    }
+	sub, ok := conn.subscriptions[id]
+	if !ok {
+		// subscription already removed
+		return nil
+	}
 
-    // remove the subscription
-    delete(conn.subscriptions, id)
+	// remove the subscription
+	delete(conn.subscriptions, id)
 
-    conn.events <- &ConnEvent{
-        ConnId:      conn.GetId(),
-        eventType:   UnsubscribeFromTopic,
-        conn:        conn,
-        sub:         sub,
-        destination: sub.destination,
-    }
+	conn.events <- &ConnEvent{
+		ConnId:      conn.GetId(),
+		eventType:   UnsubscribeFromTopic,
+		conn:        conn,
+		sub:         sub,
+		destination: sub.destination,
+	}
 
-    return nil
+	return nil
 }
 
 func (conn *stompConn) handleSend(f *frame.Frame) error {
-    switch atomic.LoadInt32(&conn.state) {
-    case connecting:
-        return notConnectedStompError
-    case closed:
-        return nil
-    }
+	switch atomic.LoadInt32(&conn.state) {
+	case connecting:
+		return notConnectedStompError
+	case closed:
+		return nil
+	}
 
-    // TODO: Remove if we start supporting transactions
-    if  containsHeader(f, frame.Transaction) {
-        return unsupportedStompCommandError
-    }
+	// TODO: Remove if we start supporting transactions
+	if containsHeader(f, frame.Transaction) {
+		return unsupportedStompCommandError
+	}
 
-    // no destination triggers an error
-    dest, ok := f.Header.Contains(frame.Destination)
-    if !ok {
-        return invalidFrameError
-    }
+	// no destination triggers an error
+	dest, ok := f.Header.Contains(frame.Destination)
+	if !ok {
+		return invalidFrameError
+	}
 
-    // reject SENDing directly to non-request channels by clients
-    if !conn.config.IsAppRequestDestination(f.Header.Get(frame.Destination)) {
-        return invalidSendDestinationError
-    }
+	// reject SENDing directly to non-request channels by clients
+	if !conn.config.IsAppRequestDestination(f.Header.Get(frame.Destination)) {
+		return invalidSendDestinationError
+	}
 
-    err := conn.sendReceiptResponse(f)
-    if err != nil {
-        return err
-    }
+	err := conn.sendReceiptResponse(f)
+	if err != nil {
+		return err
+	}
 
-    f.Command = frame.MESSAGE
-    conn.events <- &ConnEvent{
-        ConnId:      conn.GetId(),
-        eventType:   IncomingMessage,
-        destination: dest,
-        frame:       f,
-        conn:        conn,
-    }
+	f.Command = frame.MESSAGE
+	conn.events <- &ConnEvent{
+		ConnId:      conn.GetId(),
+		eventType:   IncomingMessage,
+		destination: dest,
+		frame:       f,
+		conn:        conn,
+	}
 
-    return nil
+	return nil
 }
 
 func (conn *stompConn) sendReceiptResponse(f *frame.Frame) error {
-    if receipt, ok := f.Header.Contains(frame.Receipt); ok {
-        f.Header.Del(frame.Receipt)
-        return conn.rawConnection.WriteFrame(frame.New(frame.RECEIPT, frame.ReceiptId, receipt))
-    }
-    return nil
+	if receipt, ok := f.Header.Contains(frame.Receipt); ok {
+		f.Header.Del(frame.Receipt)
+		return conn.rawConnection.WriteFrame(frame.New(frame.RECEIPT, frame.ReceiptId, receipt))
+	}
+	return nil
 }
 
 func (conn *stompConn) readInFrames() {
-    defer func() {
-        close(conn.inFrames)
-    }()
+	defer func() {
+		close(conn.inFrames)
+	}()
 
-    infiniteTimeout := time.Time{}
-    var readTimeoutMs int64 = 0
-    for {
-        readTimeoutMs = atomic.LoadInt64(&conn.readTimeoutMs)
-        if readTimeoutMs > 0 {
-            conn.rawConnection.SetReadDeadline(time.Now().Add(
-                time.Duration(readTimeoutMs) * time.Millisecond))
-        } else {
-            conn.rawConnection.SetReadDeadline(infiniteTimeout)
-        }
+	infiniteTimeout := time.Time{}
+	var readTimeoutMs int64 = 0
+	for {
+		readTimeoutMs = atomic.LoadInt64(&conn.readTimeoutMs)
+		if readTimeoutMs > 0 {
+			conn.rawConnection.SetReadDeadline(time.Now().Add(
+				time.Duration(readTimeoutMs) * time.Millisecond))
+		} else {
+			conn.rawConnection.SetReadDeadline(infiniteTimeout)
+		}
 
-        f, err := conn.rawConnection.ReadFrame()
-        if err != nil {
-            return
-        }
+		f, err := conn.rawConnection.ReadFrame()
+		if err != nil {
+			return
+		}
 
-        if f == nil {
-            // heartbeat frame
-            continue
-        }
+		if f == nil {
+			// heartbeat frame
+			continue
+		}
 
-        conn.inFrames <- f
-    }
+		conn.inFrames <- f
+	}
 }
 
 func determineVersion(f *frame.Frame) (stomp.Version, error) {
-    if acceptVersion, ok := f.Header.Contains(frame.AcceptVersion); ok {
-        versions := strings.Split(acceptVersion, ",")
-        for _, supportedVersion := range []stomp.Version{stomp.V12, stomp.V11, stomp.V10} {
-            for _, v := range versions {
-                if v == supportedVersion.String() {
-                    // return the highest supported version
-                    return supportedVersion, nil
-                }
-            }
-        }
-    } else {
-        return stomp.V10, nil
-    }
+	if acceptVersion, ok := f.Header.Contains(frame.AcceptVersion); ok {
+		versions := strings.Split(acceptVersion, ",")
+		for _, supportedVersion := range []stomp.Version{stomp.V12, stomp.V11, stomp.V10} {
+			for _, v := range versions {
+				if v == supportedVersion.String() {
+					// return the highest supported version
+					return supportedVersion, nil
+				}
+			}
+		}
+	} else {
+		return stomp.V10, nil
+	}
 
-    var emptyVersion stomp.Version
-    return emptyVersion, unsupportedStompVersionError
+	var emptyVersion stomp.Version
+	return emptyVersion, unsupportedStompVersionError
 }
 
 func getHeartBeat(f *frame.Frame) (cx, cy time.Duration, err error) {
-    if heartBeat, ok := f.Header.Contains(frame.HeartBeat); ok {
-        return frame.ParseHeartBeat(heartBeat)
-    }
-    return 0, 0, nil
+	if heartBeat, ok := f.Header.Contains(frame.HeartBeat); ok {
+		return frame.ParseHeartBeat(heartBeat)
+	}
+	return 0, 0, nil
 }
 
 func (conn *stompConn) sendError(err error) {
-    errorFrame := frame.New(frame.ERROR,
-        frame.Message, err.Error())
+	errorFrame := frame.New(frame.ERROR,
+		frame.Message, err.Error())
 
-    conn.rawConnection.WriteFrame(errorFrame)
+	conn.rawConnection.WriteFrame(errorFrame)
 }
 
 func (conn *stompConn) populateMessageIdHeader(f *frame.Frame) {
-    if f.Command == frame.MESSAGE {
-        // allocate the value of message-id for this frame
-        conn.currentMessageId++
-        messageId := strconv.FormatUint(conn.currentMessageId, 10)
-        f.Header.Set(frame.MessageId, messageId)
-        // remove the Ack header (if any) as we don't support those
-        f.Header.Del(frame.Ack)
-    }
+	if f.Command == frame.MESSAGE {
+		// allocate the value of message-id for this frame
+		conn.currentMessageId++
+		messageId := strconv.FormatUint(conn.currentMessageId, 10)
+		f.Header.Set(frame.MessageId, messageId)
+		// remove the Ack header (if any) as we don't support those
+		f.Header.Del(frame.Ack)
+	}
 }

--- a/stompserver/stomp_connection_test.go
+++ b/stompserver/stomp_connection_test.go
@@ -4,830 +4,830 @@
 package stompserver
 
 import (
-    "errors"
-    "fmt"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/stretchr/testify/assert"
-    "sync"
-    "testing"
-    "time"
+	"errors"
+	"fmt"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
 )
 
 type MockRawConnection struct {
-    connected bool
-    incomingFrames chan interface{}
-    lock sync.Mutex
-    currentDeadline time.Time
-    sentFrames []*frame.Frame
-    nextWriteErr error
-    nextReadErr error
-    writeWg *sync.WaitGroup
+	connected       bool
+	incomingFrames  chan interface{}
+	lock            sync.Mutex
+	currentDeadline time.Time
+	sentFrames      []*frame.Frame
+	nextWriteErr    error
+	nextReadErr     error
+	writeWg         *sync.WaitGroup
 }
 
 func NewMockRawConnection() *MockRawConnection {
-    return &MockRawConnection{
-        connected: true,
-        incomingFrames: make(chan interface{}),
-        sentFrames: []*frame.Frame{},
-        nextWriteErr: nil,
-    }
+	return &MockRawConnection{
+		connected:      true,
+		incomingFrames: make(chan interface{}),
+		sentFrames:     []*frame.Frame{},
+		nextWriteErr:   nil,
+	}
 }
 
 func (con *MockRawConnection) ReadFrame() (*frame.Frame, error) {
-    obj := <- con.incomingFrames
+	obj := <-con.incomingFrames
 
-    if obj == nil {
-        // heart-beat
-        return nil, nil
-    }
+	if obj == nil {
+		// heart-beat
+		return nil, nil
+	}
 
-    f, ok := obj.(*frame.Frame)
-    if ok {
-        return f, nil
-    }
+	f, ok := obj.(*frame.Frame)
+	if ok {
+		return f, nil
+	}
 
-    return nil, obj.(error)
+	return nil, obj.(error)
 }
 
 func (con *MockRawConnection) WriteFrame(frame *frame.Frame) error {
-    defer func() { con.nextWriteErr = nil}()
-    if con.nextWriteErr != nil {
-        return con.nextWriteErr
-    }
+	defer func() { con.nextWriteErr = nil }()
+	if con.nextWriteErr != nil {
+		return con.nextWriteErr
+	}
 
-    con.lock.Lock()
-    con.sentFrames = append(con.sentFrames, frame)
-    if con.writeWg != nil {
-        con.writeWg.Done()
-    }
-    con.lock.Unlock()
-    return nil
+	con.lock.Lock()
+	con.sentFrames = append(con.sentFrames, frame)
+	if con.writeWg != nil {
+		con.writeWg.Done()
+	}
+	con.lock.Unlock()
+	return nil
 }
 
 func (con *MockRawConnection) LastSentFrame() *frame.Frame {
-    return con.sentFrames[len(con.sentFrames) - 1]
+	return con.sentFrames[len(con.sentFrames)-1]
 }
 
 func (con *MockRawConnection) SetReadDeadline(t time.Time) {
-    con.lock.Lock()
-    con.currentDeadline = t
-    con.lock.Unlock()
+	con.lock.Lock()
+	con.currentDeadline = t
+	con.lock.Unlock()
 }
 
 func (con *MockRawConnection) getCurrentReadDeadline() time.Time {
-    con.lock.Lock()
-    defer con.lock.Unlock()
-    return con.currentDeadline
+	con.lock.Lock()
+	defer con.lock.Unlock()
+	return con.currentDeadline
 }
 
 func (con *MockRawConnection) Close() error {
-    con.connected = false
-    return nil
+	con.connected = false
+	return nil
 }
 
 func (con *MockRawConnection) SendConnectFrame() {
-    con.incomingFrames <- frame.New(
-        frame.CONNECT,
-        frame.AcceptVersion, "1.2")
+	con.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.2")
 }
 
 func getTestStompConn(conf StompConfig, events chan *ConnEvent) (*stompConn, *MockRawConnection, chan *ConnEvent) {
-    if events == nil {
-        events = make(chan *ConnEvent, 1000)
-    }
+	if events == nil {
+		events = make(chan *ConnEvent, 1000)
+	}
 
-    rawConn := NewMockRawConnection()
-    return NewStompConn(rawConn, conf, events).(*stompConn), rawConn, events
+	rawConn := NewMockRawConnection()
+	return NewStompConn(rawConn, conf, events).(*stompConn), rawConn, events
 }
 
 func TestStompConn_Connect(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.NotNil(t, stompConn.GetId())
+	assert.NotNil(t, stompConn.GetId())
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "1.0,1.2,1.1,1.3")
+	rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "1.0,1.2,1.1,1.3")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionEstablished)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionEstablished)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
-            frame.Version, "1.2",
-            frame.HeartBeat, "0,0",
-            frame.Server, "stompServer/0.0.1"), true)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
+		frame.Version, "1.2",
+		frame.HeartBeat, "0,0",
+		frame.Server, "stompServer/0.0.1"), true)
 
-    assert.Equal(t, stompConn.state, connected)
+	assert.Equal(t, stompConn.state, connected)
 }
 
 func TestStompConn_ConnectStomp10(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "1.0")
+	rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "1.0")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, unsupportedStompVersionError.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, unsupportedStompVersionError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_ConnectInvalidStompVersion(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "5.0")
+	rawConn.incomingFrames <- frame.New(frame.CONNECT, frame.AcceptVersion, "5.0")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, unsupportedStompVersionError.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, unsupportedStompVersionError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_ConnectWithReceiptHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT,
-        frame.AcceptVersion, "1.2",
-        frame.Receipt, "receipt-id")
+	rawConn.incomingFrames <- frame.New(frame.CONNECT,
+		frame.AcceptVersion, "1.2",
+		frame.Receipt, "receipt-id")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, invalidHeaderError.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, invalidHeaderError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_ConnectMissingStompVersionHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT)
+	rawConn.incomingFrames <- frame.New(frame.CONNECT)
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, unsupportedStompVersionError.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, unsupportedStompVersionError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_ConnectInvalidHeartbeatHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New(frame.CONNECT,
-        frame.AcceptVersion, "1.2",
-        frame.HeartBeat, "12,asd")
+	rawConn.incomingFrames <- frame.New(frame.CONNECT,
+		frame.AcceptVersion, "1.2",
+		frame.HeartBeat, "12,asd")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, frame.ErrInvalidHeartBeat.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, frame.ErrInvalidHeartBeat.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_InvalidStompCommand(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    assert.Equal(t, stompConn.state, connecting)
+	assert.Equal(t, stompConn.state, connecting)
 
-    rawConn.incomingFrames <- frame.New("invalid-stomp-command",
-        frame.AcceptVersion, "1.2")
+	rawConn.incomingFrames <- frame.New("invalid-stomp-command",
+		frame.AcceptVersion, "1.2")
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, unsupportedStompCommandError.Error()), true)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, unsupportedStompCommandError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_ConnectNoServerHeartbeat(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-            frame.CONNECT,
-            frame.AcceptVersion, "1.1,1.0",
-            frame.HeartBeat, "4000,4000")
+	rawConn.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.1,1.0",
+		frame.HeartBeat, "4000,4000")
 
-    <- events
+	<-events
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
-        frame.Version, "1.1",
-        frame.HeartBeat, "0,0"), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
+		frame.Version, "1.1",
+		frame.HeartBeat, "0,0"), false)
 }
 
 func TestStompConn_ConnectServerHeartbeat(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(9999999991, []string{}), nil)
-    rawConn.incomingFrames <- frame.New(
-        frame.CONNECT,
-        frame.AcceptVersion, "1.1,1.0",
-        frame.HeartBeat, "4000,4000")
+	_, rawConn, events := getTestStompConn(NewStompConfig(9999999991, []string{}), nil)
+	rawConn.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.1,1.0",
+		frame.HeartBeat, "4000,4000")
 
-    <- events
+	<-events
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
-        frame.Version, "1.1",
-        frame.HeartBeat, "999999999,999999999"), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
+		frame.Version, "1.1",
+		frame.HeartBeat, "999999999,999999999"), false)
 }
 
 func TestStompConn_ConnectClientHeartbeat(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(7000, []string{}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(7000, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.CONNECT,
-        frame.AcceptVersion, "1.2",
-        frame.HeartBeat, "8000,9000")
+	rawConn.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.2",
+		frame.HeartBeat, "8000,9000")
 
-    <- events
+	<-events
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
-        frame.HeartBeat, "9000,8000"), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED,
+		frame.HeartBeat, "9000,8000"), false)
 }
 
 func TestStompConn_ConnectWhenConnected(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, unexpectedStompCommandError.Error()), true)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, unexpectedStompCommandError.Error()), true)
 
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_SubscribeNotConnected(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Destination, "/topic/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Destination, "/topic/test")
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, e.conn, stompConn)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, e.conn, stompConn)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, notConnectedStompError.Error()), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, notConnectedStompError.Error()), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_SubscribeMissingIdHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Destination, "/topic/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Destination, "/topic/test")
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, invalidSubscriptionError.Error()), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, invalidSubscriptionError.Error()), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_SubscribeMissingDestinationHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Id, "sub-id")
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Id, "sub-id")
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, invalidFrameError.Error()), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, invalidFrameError.Error()), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_Subscribe(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Id, "sub-id",
-        frame.Destination, "/topic/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Id, "sub-id",
+		frame.Destination, "/topic/test")
 
-    e = <- events
-    assert.Equal(t, e.eventType, SubscribeToTopic)
-    assert.Equal(t, e.conn, stompConn)
-    assert.Equal(t, e.destination, "/topic/test")
-    assert.Equal(t, e.sub.destination, "/topic/test")
-    assert.Equal(t, e.sub.id, "sub-id")
-    assert.Equal(t, e.frame.Command, frame.SUBSCRIBE)
+	e = <-events
+	assert.Equal(t, e.eventType, SubscribeToTopic)
+	assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.destination, "/topic/test")
+	assert.Equal(t, e.sub.destination, "/topic/test")
+	assert.Equal(t, e.sub.id, "sub-id")
+	assert.Equal(t, e.frame.Command, frame.SUBSCRIBE)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    assert.Equal(t, stompConn.state, connected)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, stompConn.state, connected)
 
-    assert.Equal(t, stompConn.subscriptions["sub-id"].destination, "/topic/test")
+	assert.Equal(t, stompConn.subscriptions["sub-id"].destination, "/topic/test")
 
-    // trigger send subscribe request with the same id
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Id, "sub-id",
-        frame.Destination, "/topic/test")
+	// trigger send subscribe request with the same id
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Id, "sub-id",
+		frame.Destination, "/topic/test")
 
-    // verify that there was no second subscription created for the same subscription id
-    assert.Equal(t, e.sub, stompConn.subscriptions["sub-id"])
+	// verify that there was no second subscription created for the same subscription id
+	assert.Equal(t, e.sub, stompConn.subscriptions["sub-id"])
 }
 
 func TestStompConn_SendNotConnected(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SEND,
-        frame.Destination, "/pub/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.SEND,
+		frame.Destination, "/pub/test")
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, notConnectedStompError.Error()), true)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, notConnectedStompError.Error()), true)
 }
 
 func TestStompConn_SendMissingDestinationHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SEND)
+	rawConn.incomingFrames <- frame.New(
+		frame.SEND)
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, invalidFrameError.Error()), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, invalidFrameError.Error()), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_Send_InvalidSend(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
 
-    // try sending a frame to a topic channel directly not request channel
-    rawConn.incomingFrames <- frame.New(frame.SEND,
-        frame.Destination, "/topic/test")
-    e = <- events
+	// try sending a frame to a topic channel directly not request channel
+	rawConn.incomingFrames <- frame.New(frame.SEND,
+		frame.Destination, "/topic/test")
+	e = <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, invalidSendDestinationError.Error()), true)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, invalidSendDestinationError.Error()), true)
 }
 
 func TestStompConn_Send(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    msgF := frame.New(frame.SEND, frame.Destination, "/pub/test")
+	msgF := frame.New(frame.SEND, frame.Destination, "/pub/test")
 
-    rawConn.incomingFrames <- msgF
+	rawConn.incomingFrames <- msgF
 
-    e = <- events
-    assert.Equal(t, e.eventType, IncomingMessage)
-    assert.Equal(t, e.frame, msgF)
-    assert.Equal(t, e.frame.Command, frame.MESSAGE)
+	e = <-events
+	assert.Equal(t, e.eventType, IncomingMessage)
+	assert.Equal(t, e.frame, msgF)
+	assert.Equal(t, e.frame.Command, frame.MESSAGE)
 
-    rawConn.incomingFrames <- frame.New(frame.SEND,
-            frame.Destination, "/pub/test", frame.Receipt, "receipt-id")
+	rawConn.incomingFrames <- frame.New(frame.SEND,
+		frame.Destination, "/pub/test", frame.Receipt, "receipt-id")
 
-    e = <- events
-    assert.Equal(t, e.eventType, IncomingMessage)
+	e = <-events
+	assert.Equal(t, e.eventType, IncomingMessage)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.RECEIPT,
-        frame.ReceiptId, "receipt-id"), true)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.RECEIPT,
+		frame.ReceiptId, "receipt-id"), true)
 }
 
 func TestStompConn_UnsubscribeNotConnected(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE,
-        frame.Destination, "/topic/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE,
+		frame.Destination, "/topic/test")
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, notConnectedStompError.Error()), true)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, notConnectedStompError.Error()), true)
 }
 
 func TestStompConn_UnsubscribeMissingIdHeader(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE)
+	rawConn.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE)
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
-        frame.Message, invalidSubscriptionError.Error()), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.ERROR,
+		frame.Message, invalidSubscriptionError.Error()), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_Unsubscribe(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE,
-        frame.Id, "invalid-sub-id",
-        frame.Receipt, "receipt-id")
+	rawConn.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE,
+		frame.Id, "invalid-sub-id",
+		frame.Receipt, "receipt-id")
 
-    rawConn.incomingFrames <- frame.New(
-        frame.SUBSCRIBE,
-        frame.Id, "sub-id",
-        frame.Destination, "/topic/test")
+	rawConn.incomingFrames <- frame.New(
+		frame.SUBSCRIBE,
+		frame.Id, "sub-id",
+		frame.Destination, "/topic/test")
 
-    e = <- events
-    assert.Equal(t, e.eventType, SubscribeToTopic)
+	e = <-events
+	assert.Equal(t, e.eventType, SubscribeToTopic)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.RECEIPT,
-        frame.ReceiptId, "receipt-id"), true)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1], frame.New(frame.RECEIPT,
+		frame.ReceiptId, "receipt-id"), true)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.UNSUBSCRIBE,
-        frame.Id, "sub-id")
+	rawConn.incomingFrames <- frame.New(
+		frame.UNSUBSCRIBE,
+		frame.Id, "sub-id")
 
-    e = <- events
-    assert.Equal(t, e.eventType, UnsubscribeFromTopic)
-    assert.Equal(t, e.conn, stompConn)
-    assert.Equal(t, e.destination, "/topic/test")
-    assert.Equal(t, e.sub.destination, "/topic/test")
-    assert.Equal(t, e.sub.id, "sub-id")
+	e = <-events
+	assert.Equal(t, e.eventType, UnsubscribeFromTopic)
+	assert.Equal(t, e.conn, stompConn)
+	assert.Equal(t, e.destination, "/topic/test")
+	assert.Equal(t, e.sub.destination, "/topic/test")
+	assert.Equal(t, e.sub.id, "sub-id")
 
-    assert.Equal(t, len(stompConn.subscriptions), 0)
-    assert.Equal(t, stompConn.state, connected)
+	assert.Equal(t, len(stompConn.subscriptions), 0)
+	assert.Equal(t, stompConn.state, connected)
 }
 
 func TestStompConn_DisconnectNotConnected(t *testing.T) {
-    _, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	_, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.DISCONNECT)
+	rawConn.incomingFrames <- frame.New(
+		frame.DISCONNECT)
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
-        frame.Message, notConnectedStompError.Error()), true)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.ERROR,
+		frame.Message, notConnectedStompError.Error()), true)
 }
 
 func TestStompConn_Disconnect(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <- events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.DISCONNECT)
+	rawConn.incomingFrames <- frame.New(
+		frame.DISCONNECT)
 
-    e = <- events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_DisconnectWithReceipt(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <-events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    assert.Equal(t, len(rawConn.sentFrames), 1)
-    verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
+	verifyFrame(t, rawConn.sentFrames[0], frame.New(frame.CONNECTED), false)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.DISCONNECT,
-        frame.Receipt, "test-receipt")
+	rawConn.incomingFrames <- frame.New(
+		frame.DISCONNECT,
+		frame.Receipt, "test-receipt")
 
-    e = <-events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e = <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    verifyFrame(t, rawConn.sentFrames[1],
-        frame.New(frame.RECEIPT, frame.ReceiptId, "test-receipt"), true)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	verifyFrame(t, rawConn.sentFrames[1],
+		frame.New(frame.RECEIPT, frame.ReceiptId, "test-receipt"), true)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_Close(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    stompConn.Close()
+	stompConn.Close()
 
-    e := <-events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 0)
-    assert.Equal(t, stompConn.state, closed)
-    assert.Equal(t, rawConn.connected, false)
+	assert.Equal(t, len(rawConn.sentFrames), 0)
+	assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, rawConn.connected, false)
 }
 
 func TestStompConn_SendFrameToSubscription(t *testing.T) {
-    stompConn, rawConn, _ := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, _ := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    sub := &subscription{
-        id: "sub-id",
-        destination: "/topic/test",
-    }
+	sub := &subscription{
+		id:          "sub-id",
+		destination: "/topic/test",
+	}
 
-    f := frame.New(frame.MESSAGE, frame.Destination, "/topic/test")
+	f := frame.New(frame.MESSAGE, frame.Destination, "/topic/test")
 
-    rawConn.writeWg = &sync.WaitGroup{}
-    rawConn.writeWg.Add(1)
+	rawConn.writeWg = &sync.WaitGroup{}
+	rawConn.writeWg.Add(1)
 
-    stompConn.SendFrameToSubscription(f, sub)
+	stompConn.SendFrameToSubscription(f, sub)
 
-    rawConn.writeWg.Wait()
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	rawConn.writeWg.Wait()
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 
-    assert.Equal(t, rawConn.sentFrames[0], f)
-    assert.Equal(t, rawConn.sentFrames[0].Header.Get(frame.MessageId), "1")
+	assert.Equal(t, rawConn.sentFrames[0], f)
+	assert.Equal(t, rawConn.sentFrames[0].Header.Get(frame.MessageId), "1")
 
-    rawConn.writeWg.Add(1)
-    stompConn.SendFrameToSubscription(f, sub)
-    rawConn.writeWg.Wait()
-    assert.Equal(t, len(rawConn.sentFrames), 2)
-    assert.Equal(t, rawConn.sentFrames[1].Header.Get(frame.MessageId), "2")
+	rawConn.writeWg.Add(1)
+	stompConn.SendFrameToSubscription(f, sub)
+	rawConn.writeWg.Wait()
+	assert.Equal(t, len(rawConn.sentFrames), 2)
+	assert.Equal(t, rawConn.sentFrames[1].Header.Get(frame.MessageId), "2")
 
-    rawConn.writeWg.Add(50)
-    for i := 0; i < 50; i++ {
-        go stompConn.SendFrameToSubscription(f.Clone(), sub)
-    }
+	rawConn.writeWg.Add(50)
+	for i := 0; i < 50; i++ {
+		go stompConn.SendFrameToSubscription(f.Clone(), sub)
+	}
 
-    rawConn.writeWg.Wait()
-    assert.Equal(t, len(rawConn.sentFrames), 52)
+	rawConn.writeWg.Wait()
+	assert.Equal(t, len(rawConn.sentFrames), 52)
 }
 
 func TestStompConn_SendErrorFrameToSubscription(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    sub := &subscription{
-        id: "sub-id",
-        destination: "/topic/test",
-    }
+	sub := &subscription{
+		id:          "sub-id",
+		destination: "/topic/test",
+	}
 
-    f := frame.New(frame.ERROR, frame.Destination, "/topic/test")
-    stompConn.SendFrameToSubscription(f, sub)
+	f := frame.New(frame.ERROR, frame.Destination, "/topic/test")
+	stompConn.SendFrameToSubscription(f, sub)
 
-    e := <- events
+	e := <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, len(rawConn.sentFrames), 1)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, len(rawConn.sentFrames), 1)
 }
 
 func TestStompConn_ReadError(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.incomingFrames <- errors.New("read error")
+	rawConn.incomingFrames <- errors.New("read error")
 
-    e := <-events
-    assert.Equal(t, e.eventType, ConnectionClosed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
 
-    assert.Equal(t, len(rawConn.sentFrames), 0)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, len(rawConn.sentFrames), 0)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_WriteErrorDuringConnect(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{}), nil)
 
-    rawConn.nextWriteErr = errors.New("write error")
-    rawConn.SendConnectFrame()
+	rawConn.nextWriteErr = errors.New("write error")
+	rawConn.SendConnectFrame()
 
-    e := <-events
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, stompConn.state, closed)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_WriteErrorDuringSend(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(0, []string{"/pub/"}), nil)
 
-    rawConn.SendConnectFrame()
+	rawConn.SendConnectFrame()
 
-    e := <-events
-    assert.Equal(t, e.eventType, ConnectionEstablished)
+	e := <-events
+	assert.Equal(t, e.eventType, ConnectionEstablished)
 
-    rawConn.nextWriteErr = errors.New("write error")
-    rawConn.incomingFrames <- frame.New(
-        frame.SEND,
-        frame.Destination, "/pub/",
-        frame.Receipt, "receipt-id")
+	rawConn.nextWriteErr = errors.New("write error")
+	rawConn.incomingFrames <- frame.New(
+		frame.SEND,
+		frame.Destination, "/pub/",
+		frame.Receipt, "receipt-id")
 
-    e = <- events
+	e = <-events
 
-    assert.Equal(t, e.eventType, ConnectionClosed)
-    assert.Equal(t, stompConn.state, closed)
+	assert.Equal(t, e.eventType, ConnectionClosed)
+	assert.Equal(t, stompConn.state, closed)
 }
 
 func TestStompConn_SetReadDeadline(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(20000, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(20000, []string{}), nil)
 
-    infiniteTimeout := time.Time{}
+	infiniteTimeout := time.Time{}
 
-    assert.Equal(t, rawConn.getCurrentReadDeadline(), infiniteTimeout)
+	assert.Equal(t, rawConn.getCurrentReadDeadline(), infiniteTimeout)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.CONNECT,
-        frame.AcceptVersion, "1.2",
-        frame.HeartBeat, "200,200")
+	rawConn.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.2",
+		frame.HeartBeat, "200,200")
 
-    <-events
+	<-events
 
-    // verify timeout is set to 20 seconds
-    assert.Equal(t, stompConn.readTimeoutMs, int64(20000))
+	// verify timeout is set to 20 seconds
+	assert.Equal(t, stompConn.readTimeoutMs, int64(20000))
 
-    rawConn.incomingFrames <- nil
-    rawConn.incomingFrames <- nil
+	rawConn.incomingFrames <- nil
+	rawConn.incomingFrames <- nil
 
-    diff := rawConn.getCurrentReadDeadline().Sub(time.Now())
+	diff := rawConn.getCurrentReadDeadline().Sub(time.Now())
 
-    // verify the read deadline for the connection is
-    // between 15 and 21 seconds
-    assert.Greater(t, diff.Seconds(), float64(15))
-    assert.Greater(t, float64(21), diff.Seconds())
+	// verify the read deadline for the connection is
+	// between 15 and 21 seconds
+	assert.Greater(t, diff.Seconds(), float64(15))
+	assert.Greater(t, float64(21), diff.Seconds())
 }
 
 func TestStompConn_WriteHeartbeat(t *testing.T) {
-    stompConn, rawConn, events := getTestStompConn(NewStompConfig(100, []string{}), nil)
+	stompConn, rawConn, events := getTestStompConn(NewStompConfig(100, []string{}), nil)
 
-    rawConn.incomingFrames <- frame.New(
-        frame.CONNECT,
-        frame.AcceptVersion, "1.2",
-        frame.HeartBeat, "50,50")
+	rawConn.incomingFrames <- frame.New(
+		frame.CONNECT,
+		frame.AcceptVersion, "1.2",
+		frame.HeartBeat, "50,50")
 
-    <-events
+	<-events
 
-    rawConn.lock.Lock()
-    rawConn.writeWg = new(sync.WaitGroup)
-    rawConn.writeWg.Add(2)
-    rawConn.lock.Unlock()
+	rawConn.lock.Lock()
+	rawConn.writeWg = new(sync.WaitGroup)
+	rawConn.writeWg.Add(2)
+	rawConn.lock.Unlock()
 
-    rawConn.writeWg.Wait()
+	rawConn.writeWg.Wait()
 
-    // verify the last frame is heartbeat (nil)
-    rawConn.lock.Lock()
-    assert.Nil(t, rawConn.LastSentFrame())
-    rawConn.lock.Unlock()
+	// verify the last frame is heartbeat (nil)
+	rawConn.lock.Lock()
+	assert.Nil(t, rawConn.LastSentFrame())
+	rawConn.lock.Unlock()
 
-    rawConn.writeWg.Add(3)
-    stompConn.SendFrameToSubscription(frame.New(frame.MESSAGE), &subscription{id: "sub-1"})
-    rawConn.writeWg.Wait()
+	rawConn.writeWg.Add(3)
+	stompConn.SendFrameToSubscription(frame.New(frame.MESSAGE), &subscription{id: "sub-1"})
+	rawConn.writeWg.Wait()
 
-    // verify the last frame is heartbeat (nil)
-    rawConn.lock.Lock()
-    rawConn.writeWg = nil
-    assert.Nil(t, rawConn.LastSentFrame())
-    rawConn.lock.Unlock()
+	// verify the last frame is heartbeat (nil)
+	rawConn.lock.Lock()
+	rawConn.writeWg = nil
+	assert.Nil(t, rawConn.LastSentFrame())
+	rawConn.lock.Unlock()
 }
 
 func verifyFrame(t *testing.T, actualFrame *frame.Frame, expectedFrame *frame.Frame, exactHeaderMatch bool) {
-    assert.Equal(t, expectedFrame.Command, actualFrame.Command)
-    if exactHeaderMatch {
-        assert.Equal(t, expectedFrame.Header.Len(), actualFrame.Header.Len())
-    }
+	assert.Equal(t, expectedFrame.Command, actualFrame.Command)
+	if exactHeaderMatch {
+		assert.Equal(t, expectedFrame.Header.Len(), actualFrame.Header.Len())
+	}
 
-    for i := 0; i < expectedFrame.Header.Len(); i++ {
-        key, value := expectedFrame.Header.GetAt(i);
-        assert.Equal(t, actualFrame.Header.Get(key), value)
-    }
+	for i := 0; i < expectedFrame.Header.Len(); i++ {
+		key, value := expectedFrame.Header.GetAt(i)
+		assert.Equal(t, actualFrame.Header.Get(key), value)
+	}
 }
 
 func printFrame(f *frame.Frame) {
-    if f == nil {
-        fmt.Println("HEARTBEAT FRAME")
-    } else {
-        fmt.Println("FRAME:", f.Command)
-        for i := 0; i < f.Header.Len(); i++ {
-            key, value := f.Header.GetAt(i)
-            fmt.Println(key + ":", value)
-        }
-        fmt.Println("BODY:", string(f.Body))
-    }
+	if f == nil {
+		fmt.Println("HEARTBEAT FRAME")
+	} else {
+		fmt.Println("FRAME:", f.Command)
+		for i := 0; i < f.Header.Len(); i++ {
+			key, value := f.Header.GetAt(i)
+			fmt.Println(key+":", value)
+		}
+		fmt.Println("BODY:", string(f.Body))
+	}
 }

--- a/stompserver/tcp_connection_listener.go
+++ b/stompserver/tcp_connection_listener.go
@@ -4,57 +4,57 @@
 package stompserver
 
 import (
-    "time"
-    "net"
-    "github.com/go-stomp/stomp/frame"
+	"github.com/go-stomp/stomp/v3/frame"
+	"net"
+	"time"
 )
 
 type tcpStompConnection struct {
-    tcpCon net.Conn
+	tcpCon net.Conn
 }
 
 func (c *tcpStompConnection) ReadFrame() (*frame.Frame, error) {
-    frameR := frame.NewReader(c.tcpCon)
-    f, e := frameR.Read()
-    return f,e
+	frameR := frame.NewReader(c.tcpCon)
+	f, e := frameR.Read()
+	return f, e
 }
 
 func (c *tcpStompConnection) WriteFrame(f *frame.Frame) error {
-    frameWr := frame.NewWriter(c.tcpCon)
-    err := frameWr.Write(f)
-    return err
+	frameWr := frame.NewWriter(c.tcpCon)
+	err := frameWr.Write(f)
+	return err
 }
 
 func (c *tcpStompConnection) SetReadDeadline(t time.Time) {
-    c.tcpCon.SetReadDeadline(t)
+	c.tcpCon.SetReadDeadline(t)
 }
 
 func (c *tcpStompConnection) Close() error {
-    return c.tcpCon.Close()
+	return c.tcpCon.Close()
 }
 
 type tcpConnectionListener struct {
-    listener net.Listener
+	listener net.Listener
 }
 
 func NewTcpConnectionListener(addr string) (RawConnectionListener, error) {
-    tcpListener, err := net.Listen("tcp", addr)
-    if err != nil {
-        return nil, err
-    }
-    return &tcpConnectionListener{listener: tcpListener}, nil
+	tcpListener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &tcpConnectionListener{listener: tcpListener}, nil
 }
 
 func (l *tcpConnectionListener) Accept() (RawConnection, error) {
-    conn, err := l.listener.Accept()
+	conn, err := l.listener.Accept()
 
-    if err != nil {
-        return nil, err
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    return &tcpStompConnection{ tcpCon: conn }, nil
+	return &tcpStompConnection{tcpCon: conn}, nil
 }
 
 func (l *tcpConnectionListener) Close() error {
-    return l.listener.Close()
+	return l.listener.Close()
 }

--- a/stompserver/tcp_connection_listener_test.go
+++ b/stompserver/tcp_connection_listener_test.go
@@ -4,101 +4,100 @@
 package stompserver
 
 import (
-    "errors"
-    "github.com/go-stomp/stomp/frame"
-    "github.com/stretchr/testify/assert"
-    "net"
-    "testing"
-    "time"
+	"errors"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
 )
 
 type MockTcpConnListener struct {
-    serverCon net.Conn
-    acceptError error
-    connected bool
+	serverCon   net.Conn
+	acceptError error
+	connected   bool
 }
 
 func (l *MockTcpConnListener) Accept() (net.Conn, error) {
-    return l.serverCon, l.acceptError
+	return l.serverCon, l.acceptError
 }
 
 func (l *MockTcpConnListener) Close() error {
-    l.connected = false
-    return errors.New("close-error")
+	l.connected = false
+	return errors.New("close-error")
 }
 
 func (l *MockTcpConnListener) Addr() net.Addr {
-    return nil
+	return nil
 }
 
 func TestTcpConnectionListener_NewListenerInvalidAddr(t *testing.T) {
-    tcpListener, err := NewTcpConnectionListener("invalid-addr")
-    assert.Nil(t, tcpListener)
-    assert.NotNil(t, err)
+	tcpListener, err := NewTcpConnectionListener("invalid-addr")
+	assert.Nil(t, tcpListener)
+	assert.NotNil(t, err)
 }
 
 func TestTcpConnectionListener_Accept(t *testing.T) {
 
-    serverConn, clientConn := net.Pipe()
+	serverConn, clientConn := net.Pipe()
 
-    mockL := &MockTcpConnListener{
-        connected: true,
-        serverCon: serverConn,
-        acceptError: nil,
-    }
+	mockL := &MockTcpConnListener{
+		connected:   true,
+		serverCon:   serverConn,
+		acceptError: nil,
+	}
 
-    tcpConListener := &tcpConnectionListener{listener: mockL}
+	tcpConListener := &tcpConnectionListener{listener: mockL}
 
-    rawCon, err := tcpConListener.Accept()
-    assert.NotNil(t, rawCon)
-    assert.Nil(t, err)
+	rawCon, err := tcpConListener.Accept()
+	assert.NotNil(t, rawCon)
+	assert.Nil(t, err)
 
-    go func() {
-        wr := frame.NewWriter(clientConn)
-        wr.Write(frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"))
-    }()
+	go func() {
+		wr := frame.NewWriter(clientConn)
+		wr.Write(frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"))
+	}()
 
-    f, readErr := rawCon.ReadFrame()
+	f, readErr := rawCon.ReadFrame()
 
-    assert.Nil(t, readErr)
-    verifyFrame(t, f, frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"), true)
+	assert.Nil(t, readErr)
+	verifyFrame(t, f, frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"), true)
 
-    frameReader := frame.NewReader(clientConn)
+	frameReader := frame.NewReader(clientConn)
 
-    go rawCon.WriteFrame(frame.New(frame.CONNECTED, frame.Version, "1.2"))
+	go rawCon.WriteFrame(frame.New(frame.CONNECTED, frame.Version, "1.2"))
 
-    serverFrame, writeErr := frameReader.Read()
-    assert.NotNil(t, serverFrame)
-    assert.Nil(t, writeErr)
+	serverFrame, writeErr := frameReader.Read()
+	assert.NotNil(t, serverFrame)
+	assert.Nil(t, writeErr)
 
-    verifyFrame(t, serverFrame, frame.New(frame.CONNECTED, frame.Version, "1.2"), true)
+	verifyFrame(t, serverFrame, frame.New(frame.CONNECTED, frame.Version, "1.2"), true)
 
-    rawCon.SetReadDeadline(time.Now().Add(time.Duration(-1) * time.Second))
-    _, timeoutErr := rawCon.ReadFrame()
+	rawCon.SetReadDeadline(time.Now().Add(time.Duration(-1) * time.Second))
+	_, timeoutErr := rawCon.ReadFrame()
 
-    assert.NotNil(t, timeoutErr)
+	assert.NotNil(t, timeoutErr)
 
-    rawCon.SetReadDeadline(time.Time{})
+	rawCon.SetReadDeadline(time.Time{})
 
-    assert.Nil(t, rawCon.Close())
+	assert.Nil(t, rawCon.Close())
 
-    n, _ := serverConn.Read(make([]byte, 1))
-    assert.Equal(t, n, 0)
+	n, _ := serverConn.Read(make([]byte, 1))
+	assert.Equal(t, n, 0)
 
-    assert.EqualError(t, tcpConListener.Close(), "close-error")
+	assert.EqualError(t, tcpConListener.Close(), "close-error")
 }
 
 func TestTcpConnectionListener_AcceptError(t *testing.T) {
-    mockL := &MockTcpConnListener{
-        connected: true,
-        serverCon: nil,
-        acceptError: errors.New("accept-error"),
-    }
+	mockL := &MockTcpConnListener{
+		connected:   true,
+		serverCon:   nil,
+		acceptError: errors.New("accept-error"),
+	}
 
-    tcpConListener := &tcpConnectionListener{listener: mockL}
+	tcpConListener := &tcpConnectionListener{listener: mockL}
 
-    rawCon, err := tcpConListener.Accept()
-    assert.Nil(t, rawCon)
-    assert.EqualError(t, err, "accept-error")
+	rawCon, err := tcpConListener.Accept()
+	assert.Nil(t, rawCon)
+	assert.EqualError(t, err, "accept-error")
 }
-

--- a/stompserver/websocket_connection_listener.go
+++ b/stompserver/websocket_connection_listener.go
@@ -4,173 +4,171 @@
 package stompserver
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "github.com/gorilla/mux"
-    "github.com/gorilla/websocket"
-    "net"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 )
 
 type webSocketStompConnection struct {
-    wsCon *websocket.Conn
+	wsCon *websocket.Conn
 }
 
 func (c *webSocketStompConnection) ReadFrame() (*frame.Frame, error) {
-    _, r, err := c.wsCon.NextReader()
-    if err != nil {
-        return nil, err
-    }
-    frameR := frame.NewReader(r)
-    f, e := frameR.Read()
-    return f,e
+	_, r, err := c.wsCon.NextReader()
+	if err != nil {
+		return nil, err
+	}
+	frameR := frame.NewReader(r)
+	f, e := frameR.Read()
+	return f, e
 }
 
 func (c *webSocketStompConnection) WriteFrame(f *frame.Frame) error {
-    wr, err := c.wsCon.NextWriter(websocket.TextMessage)
-    if err != nil {
-        return err
-    }
-    frameWr := frame.NewWriter(wr)
-    err = frameWr.Write(f)
-    if err != nil {
-        return err
-    }
-    err = wr.Close()
-    return err
+	wr, err := c.wsCon.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+	frameWr := frame.NewWriter(wr)
+	err = frameWr.Write(f)
+	if err != nil {
+		return err
+	}
+	err = wr.Close()
+	return err
 }
 
 func (c *webSocketStompConnection) SetReadDeadline(t time.Time) {
-    c.wsCon.SetReadDeadline(t)
+	c.wsCon.SetReadDeadline(t)
 }
 
 func (c *webSocketStompConnection) Close() error {
-    return c.wsCon.Close()
+	return c.wsCon.Close()
 }
 
 type webSocketConnectionListener struct {
-    httpServer *http.Server
-    requestHandler *http.ServeMux
-    tcpConnectionListener net.Listener
-    connectionsChannel chan rawConnResult
-    allowedOrigins []string
+	httpServer            *http.Server
+	requestHandler        *http.ServeMux
+	tcpConnectionListener net.Listener
+	connectionsChannel    chan rawConnResult
+	allowedOrigins        []string
 }
 
 type rawConnResult struct {
-    conn RawConnection
-    err error
+	conn RawConnection
+	err  error
 }
 
 func NewWebSocketConnectionFromExistingHttpServer(httpServer *http.Server, handler *mux.Router,
-    endpoint string, allowedOrigins []string) (RawConnectionListener, error) {
-    l := &webSocketConnectionListener{
-        httpServer: httpServer,
-        connectionsChannel: make(chan rawConnResult),
-        allowedOrigins: allowedOrigins,
-    }
+	endpoint string, allowedOrigins []string) (RawConnectionListener, error) {
+	l := &webSocketConnectionListener{
+		httpServer:         httpServer,
+		connectionsChannel: make(chan rawConnResult),
+		allowedOrigins:     allowedOrigins,
+	}
 
-    var upgrader = websocket.Upgrader{
-        ReadBufferSize:  1024,
-        WriteBufferSize: 1024,
-    }
+	var upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
 
-    upgrader.CheckOrigin = l.checkOrigin
+	upgrader.CheckOrigin = l.checkOrigin
 
-    handler.HandleFunc(endpoint, func(writer http.ResponseWriter, request *http.Request) {
-        conn, err := upgrader.Upgrade(writer, request, nil)
-        if err != nil {
-            l.connectionsChannel <- rawConnResult{ err: err}
+	handler.HandleFunc(endpoint, func(writer http.ResponseWriter, request *http.Request) {
+		conn, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			l.connectionsChannel <- rawConnResult{err: err}
 
+		} else {
+			l.connectionsChannel <- rawConnResult{
+				conn: &webSocketStompConnection{
+					wsCon: conn,
+				},
+			}
+		}
+	})
 
-        } else {
-            l.connectionsChannel <- rawConnResult{
-                conn: &webSocketStompConnection{
-                    wsCon: conn,
-                },
-            }
-        }
-    })
-
-    return l, nil
+	return l, nil
 }
 
 func NewWebSocketConnectionListener(addr string, endpoint string, allowedOrigins []string) (RawConnectionListener, error) {
-    rh := http.NewServeMux()
-    l := &webSocketConnectionListener{
-        requestHandler: rh,
-        httpServer: &http.Server{
-            Addr: addr,
-            Handler: rh,
-        },
-        connectionsChannel: make(chan rawConnResult),
-        allowedOrigins: allowedOrigins,
-    }
+	rh := http.NewServeMux()
+	l := &webSocketConnectionListener{
+		requestHandler: rh,
+		httpServer: &http.Server{
+			Addr:    addr,
+			Handler: rh,
+		},
+		connectionsChannel: make(chan rawConnResult),
+		allowedOrigins:     allowedOrigins,
+	}
 
-    var upgrader = websocket.Upgrader{
-        ReadBufferSize:  1024,
-        WriteBufferSize: 1024,
-    }
+	var upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
 
-    upgrader.CheckOrigin = l.checkOrigin
+	upgrader.CheckOrigin = l.checkOrigin
 
-    rh.HandleFunc(endpoint, func(writer http.ResponseWriter, request *http.Request) {
-        conn, err := upgrader.Upgrade(writer, request, nil)
-        if err != nil {
-            l.connectionsChannel <- rawConnResult{ err: err}
+	rh.HandleFunc(endpoint, func(writer http.ResponseWriter, request *http.Request) {
+		conn, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			l.connectionsChannel <- rawConnResult{err: err}
 
+		} else {
+			l.connectionsChannel <- rawConnResult{
+				conn: &webSocketStompConnection{
+					wsCon: conn,
+				},
+			}
+		}
+	})
 
-        } else {
-            l.connectionsChannel <- rawConnResult{
-                conn: &webSocketStompConnection{
-                    wsCon: conn,
-                },
-            }
-        }
-    })
+	var err error
+	l.tcpConnectionListener, err = net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 
-    var err error
-    l.tcpConnectionListener, err = net.Listen("tcp", addr)
-    if err != nil {
-        return nil, err
-    }
-
-    go l.httpServer.Serve(l.tcpConnectionListener)
-    return l, nil
+	go l.httpServer.Serve(l.tcpConnectionListener)
+	return l, nil
 }
 
 func (l *webSocketConnectionListener) checkOrigin(r *http.Request) bool {
-    if len(l.allowedOrigins) == 0 {
-        return true
-    }
+	if len(l.allowedOrigins) == 0 {
+		return true
+	}
 
-    origin := r.Header["Origin"]
-    if len(origin) == 0 {
-        return true
-    }
-    u, err := url.Parse(origin[0])
-    if err != nil {
-        return false
-    }
-    if strings.ToLower(u.Host) == strings.ToLower(r.Host) {
-        return true
-    }
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	u, err := url.Parse(origin[0])
+	if err != nil {
+		return false
+	}
+	if strings.ToLower(u.Host) == strings.ToLower(r.Host) {
+		return true
+	}
 
-    for _, allowedOrigin := range l.allowedOrigins {
-        if strings.ToLower(u.Host) == strings.ToLower(allowedOrigin) {
-            return true
-        }
-    }
+	for _, allowedOrigin := range l.allowedOrigins {
+		if strings.ToLower(u.Host) == strings.ToLower(allowedOrigin) {
+			return true
+		}
+	}
 
-    return false
+	return false
 }
 
 func (l *webSocketConnectionListener) Accept() (RawConnection, error) {
-    cr := <- l.connectionsChannel
-    return cr.conn, cr.err
+	cr := <-l.connectionsChannel
+	return cr.conn, cr.err
 }
 
 func (l *webSocketConnectionListener) Close() error {
-    return l.httpServer.Close()
+	return l.httpServer.Close()
 }

--- a/stompserver/websocket_connection_listener_test.go
+++ b/stompserver/websocket_connection_listener_test.go
@@ -4,153 +4,153 @@
 package stompserver
 
 import (
-    "github.com/go-stomp/stomp/frame"
-    "github.com/gorilla/websocket"
-    "github.com/stretchr/testify/assert"
-    "net/http"
-    "sync"
-    "testing"
-    "time"
+	"github.com/go-stomp/stomp/v3/frame"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
 )
 
 func TestWebSocketConnectionListener_NewListenerInvalidAddr(t *testing.T) {
-    wsListener, err := NewWebSocketConnectionListener("invalid-addr", "/fabric", nil)
-    assert.Nil(t, wsListener)
-    assert.NotNil(t, err)
+	wsListener, err := NewWebSocketConnectionListener("invalid-addr", "/fabric", nil)
+	assert.Nil(t, wsListener)
+	assert.NotNil(t, err)
 }
 
 func TestWebSocketConnectionListener_CheckOrigin(t *testing.T) {
-    wsListener := &webSocketConnectionListener{
-        allowedOrigins: nil,
-    }
+	wsListener := &webSocketConnectionListener{
+		allowedOrigins: nil,
+	}
 
-    r := new(http.Request)
-    r.Header = make(http.Header)
-    r.Header["Origin"] = []string {"http://localhost:4200"}
-    r.Host = "localhost:8000"
+	r := new(http.Request)
+	r.Header = make(http.Header)
+	r.Header["Origin"] = []string{"http://localhost:4200"}
+	r.Host = "localhost:8000"
 
-    assert.Equal(t, wsListener.checkOrigin(r), true)
+	assert.Equal(t, wsListener.checkOrigin(r), true)
 
-    wsListener.allowedOrigins = make([]string, 0)
-    assert.Equal(t, wsListener.checkOrigin(r), true)
+	wsListener.allowedOrigins = make([]string, 0)
+	assert.Equal(t, wsListener.checkOrigin(r), true)
 
-    wsListener.allowedOrigins = []string {"appfabric.eng.vmware.com:4200"}
-    assert.Equal(t, wsListener.checkOrigin(r), false)
+	wsListener.allowedOrigins = []string{"appfabric.eng.vmware.com:4200"}
+	assert.Equal(t, wsListener.checkOrigin(r), false)
 
-    wsListener.allowedOrigins = []string {"appfabric.eng.vmware.com:4200", "localhost:4200"}
-    assert.Equal(t, wsListener.checkOrigin(r), true)
+	wsListener.allowedOrigins = []string{"appfabric.eng.vmware.com:4200", "localhost:4200"}
+	assert.Equal(t, wsListener.checkOrigin(r), true)
 
-    wsListener.allowedOrigins = []string {"appfabric.eng.vmware.com:4200"}
-    r.Host = "localhost:4200"
-    assert.Equal(t, wsListener.checkOrigin(r), true)
+	wsListener.allowedOrigins = []string{"appfabric.eng.vmware.com:4200"}
+	r.Host = "localhost:4200"
+	assert.Equal(t, wsListener.checkOrigin(r), true)
 
-    r.Header["Origin"] = []string {}
-    assert.Equal(t, wsListener.checkOrigin(r), true)
+	r.Header["Origin"] = []string{}
+	assert.Equal(t, wsListener.checkOrigin(r), true)
 
-    r.Header["Origin"] = []string {"http://192.168.0.%31/"}
-    assert.Equal(t, wsListener.checkOrigin(r), false)
+	r.Header["Origin"] = []string{"http://192.168.0.%31/"}
+	assert.Equal(t, wsListener.checkOrigin(r), false)
 }
 
 func TestWebSocketConnectionListener_NewListener(t *testing.T) {
 
-    listener, err := NewWebSocketConnectionListener("", "/fabric", []string{"localhost:8000"})
+	listener, err := NewWebSocketConnectionListener("", "/fabric", []string{"localhost:8000"})
 
-    assert.Nil(t, err)
-    assert.NotNil(t, listener)
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
 
-    wsListener := listener.(*webSocketConnectionListener)
+	wsListener := listener.(*webSocketConnectionListener)
 
-    wg := sync.WaitGroup{}
-    wg.Add(1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-    dialer := &websocket.Dialer{}
-    var clientConn *websocket.Conn
-    go func() {
-        var err error
-        clientConn, _, err = dialer.Dial(
-            "ws://" + wsListener.tcpConnectionListener.Addr().String() + "/fabric", nil)
-        assert.NotNil(t, clientConn)
-        assert.Nil(t, err)
+	dialer := &websocket.Dialer{}
+	var clientConn *websocket.Conn
+	go func() {
+		var err error
+		clientConn, _, err = dialer.Dial(
+			"ws://"+wsListener.tcpConnectionListener.Addr().String()+"/fabric", nil)
+		assert.NotNil(t, clientConn)
+		assert.Nil(t, err)
 
-        wg.Done()
-    }()
+		wg.Done()
+	}()
 
-    rawConn, err := listener.Accept()
-    assert.NotNil(t, rawConn)
-    assert.Nil(t, err)
+	rawConn, err := listener.Accept()
+	assert.NotNil(t, rawConn)
+	assert.Nil(t, err)
 
-    wg.Wait()
+	wg.Wait()
 
-    go func() {
-        wsWriter, _ := clientConn.NextWriter(websocket.TextMessage)
-        wr := frame.NewWriter(wsWriter)
-        wr.Write(frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"))
-        wsWriter.Close()
-    }()
+	go func() {
+		wsWriter, _ := clientConn.NextWriter(websocket.TextMessage)
+		wr := frame.NewWriter(wsWriter)
+		wr.Write(frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"))
+		wsWriter.Close()
+	}()
 
-    f, e := rawConn.ReadFrame()
+	f, e := rawConn.ReadFrame()
 
-    assert.NotNil(t, f)
-    assert.Nil(t, e)
+	assert.NotNil(t, f)
+	assert.Nil(t, e)
 
-    verifyFrame(t, f, frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"), true)
+	verifyFrame(t, f, frame.New(frame.CONNECT, frame.AcceptVersion, "1.2"), true)
 
-    wg.Add(1)
+	wg.Add(1)
 
-    go func() {
-       rawConn.WriteFrame(frame.New(frame.CONNECTED, frame.Version, "1.2"))
-       wg.Done()
-    }()
+	go func() {
+		rawConn.WriteFrame(frame.New(frame.CONNECTED, frame.Version, "1.2"))
+		wg.Done()
+	}()
 
-    _, wsReader, _ := clientConn.NextReader()
-    serverFrame, err := frame.NewReader(wsReader).Read()
-    assert.NotNil(t, serverFrame)
-    assert.Nil(t, err)
+	_, wsReader, _ := clientConn.NextReader()
+	serverFrame, err := frame.NewReader(wsReader).Read()
+	assert.NotNil(t, serverFrame)
+	assert.Nil(t, err)
 
-    wg.Wait()
+	wg.Wait()
 
-    verifyFrame(t, serverFrame, frame.New(frame.CONNECTED, frame.Version, "1.2"), true)
+	verifyFrame(t, serverFrame, frame.New(frame.CONNECTED, frame.Version, "1.2"), true)
 
-    rawConn.SetReadDeadline(time.Now().Add(time.Duration(-1) * time.Second))
-    _, timeoutErr := rawConn.ReadFrame()
+	rawConn.SetReadDeadline(time.Now().Add(time.Duration(-1) * time.Second))
+	_, timeoutErr := rawConn.ReadFrame()
 
-    assert.NotNil(t, timeoutErr)
+	assert.NotNil(t, timeoutErr)
 
-    rawConn.SetReadDeadline(time.Time{})
+	rawConn.SetReadDeadline(time.Time{})
 
-    assert.Nil(t, rawConn.Close())
+	assert.Nil(t, rawConn.Close())
 
-    _, reader, err := clientConn.NextReader()
-    assert.Nil(t, reader)
-    assert.NotNil(t, err)
+	_, reader, err := clientConn.NextReader()
+	assert.Nil(t, reader)
+	assert.NotNil(t, err)
 
-    err = rawConn.WriteFrame(frame.New(frame.MESSAGE))
-    assert.NotNil(t, err)
+	err = rawConn.WriteFrame(frame.New(frame.MESSAGE))
+	assert.NotNil(t, err)
 
-    var failedClientConn *websocket.Conn
-    wg.Add(1)
-    go func() {
-        requestHeaders := make(http.Header)
-        requestHeaders["Origin"] = []string{"http://192.168.0.%31/"}
+	var failedClientConn *websocket.Conn
+	wg.Add(1)
+	go func() {
+		requestHeaders := make(http.Header)
+		requestHeaders["Origin"] = []string{"http://192.168.0.%31/"}
 
-        var err error
-        failedClientConn, _, err = dialer.Dial(
-            "ws://" + wsListener.tcpConnectionListener.Addr().String() + "/fabric", requestHeaders)
-        assert.Nil(t, failedClientConn)
-        assert.NotNil(t, err)
-        wg.Done()
-    }()
+		var err error
+		failedClientConn, _, err = dialer.Dial(
+			"ws://"+wsListener.tcpConnectionListener.Addr().String()+"/fabric", requestHeaders)
+		assert.Nil(t, failedClientConn)
+		assert.NotNil(t, err)
+		wg.Done()
+	}()
 
-    failedConn, connErr := listener.Accept()
-    assert.Nil(t, failedConn)
-    assert.NotNil(t, connErr)
+	failedConn, connErr := listener.Accept()
+	assert.Nil(t, failedConn)
+	assert.NotNil(t, connErr)
 
-    wg.Wait()
+	wg.Wait()
 
-    listener.Close()
+	listener.Close()
 
-    clientConn2, _, err := dialer.Dial(
-        "ws://" + wsListener.tcpConnectionListener.Addr().String() + "/fabric", nil)
-    assert.Nil(t, clientConn2)
-    assert.NotNil(t, err)
+	clientConn2, _, err := dialer.Dial(
+		"ws://"+wsListener.tcpConnectionListener.Addr().String()+"/fabric", nil)
+	assert.Nil(t, clientConn2)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Upgraded to latest go-stomp (v3.0.3) that contains support for `reply-to` messaging and temporary queues. This is a feature supported in RabbitMQ and other brokers. [You can read more about it here](https://www.rabbitmq.com/direct-reply-to.html) This is a feature missing from `go-stomp`, so I added it and it was [included in v3.0.3 ](https://github.com/go-stomp/stomp/pull/114)

New `SubscribeReplyDestination()` method available on `bridge.Connection` that will set and handle these headers. Also includes `go fmt` linted files, not sure how this got missed early on. 

Also added in new plank methods that have been ported from existing platform modifications made internally.