### PR TITLE
fix: REST bridge performance

### DIFF
--- a/plank/pkg/server/core_models.go
+++ b/plank/pkg/server/core_models.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/transport-go/plank/utils"
 	"github.com/vmware/transport-go/service"
 	"github.com/vmware/transport-go/stompserver"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -70,7 +71,7 @@ type platformServer struct {
 	middlewareManager            middleware.MiddlewareManager      // middleware maanger instance
 	router                       *mux.Router                       // *mux.Router instance
 	routerConcurrencyProtection  *int32                            // atomic int32 to protect the main router being concurrently written to
-	out                          *os.File                          // platform log output pointer
+	out                          io.Writer                         // platform log output pointer
 	endpointHandlerMap           map[string]http.HandlerFunc       // internal map to store rest endpoint -handler mappings
 	serviceChanToBridgeEndpoints map[string][]string               // internal map to store service channel - endpoint handler key mappings
 	fabricConn                   stompserver.RawConnectionListener // WebSocket listener instance

--- a/plank/pkg/server/core_models.go
+++ b/plank/pkg/server/core_models.go
@@ -67,6 +67,7 @@ type PlatformServer interface {
 type platformServer struct {
 	HttpServer                   *http.Server                      // Http server instance
 	SyscallChan                  chan os.Signal                    // syscall channel to receive SIGINT, SIGKILL events
+	eventbus                     bus.EventBus                      // event bus pointer
 	serverConfig                 *PlatformServerConfig             // server config instance
 	middlewareManager            middleware.MiddlewareManager      // middleware maanger instance
 	router                       *mux.Router                       // *mux.Router instance

--- a/plank/pkg/server/core_models.go
+++ b/plank/pkg/server/core_models.go
@@ -76,12 +76,13 @@ type platformServer struct {
 	fabricConn                   stompserver.RawConnectionListener // WebSocket listener instance
 	ServerAvailability           *ServerAvailability               // server availability (not much used other than for internal monitoring for now)
 	lock                         sync.Mutex                        // lock
+	messageBridgeMap             map[string]*MessageBridge
 }
 
-// TransportChannelResponse wraps Transport *Message.Message with an error object for easier transfer
-type TransportChannelResponse struct {
-	Message *model.Message // wrapper object that contains the payload
-	Err     error          // error object if there is any
+// MessageBridge is a conduit used for returning service responses as HTTP responses
+type MessageBridge struct {
+	ServiceListenStream bus.MessageHandler  // message handler returned by bus.ListenStream responsible for relaying back messages as HTTP responses
+	payloadChannel      chan *model.Message // internal golang channel used for passing bus responses/errors across goroutines
 }
 
 // ServerAvailability contains boolean fields to indicate what components of the system are available or not

--- a/plank/pkg/server/endpointer_handler_factory.go
+++ b/plank/pkg/server/endpointer_handler_factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/vmware/transport-go/bus"
 	"github.com/vmware/transport-go/model"
 	"github.com/vmware/transport-go/plank/utils"
 	"github.com/vmware/transport-go/service"
@@ -15,7 +14,7 @@ import (
 
 // buildEndpointHandler builds a http.HandlerFunc that wraps Transport Bus operations in an HTTP request-response cycle.
 // service channel, request builder and rest bridge timeout are passed as parameters.
-func buildEndpointHandler(svcChannel string, reqBuilder service.RequestBuilder, restBridgeTimeout time.Duration, msgChan chan *model.Message) http.HandlerFunc {
+func (ps *platformServer) buildEndpointHandler(svcChannel string, reqBuilder service.RequestBuilder, restBridgeTimeout time.Duration, msgChan chan *model.Message) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -30,7 +29,7 @@ func buildEndpointHandler(svcChannel string, reqBuilder service.RequestBuilder, 
 
 		// relay the request to transport channel
 		reqModel := reqBuilder(w, r)
-		err := bus.GetBus().SendRequestMessage(svcChannel, reqModel, reqModel.Id)
+		err := ps.eventbus.SendRequestMessage(svcChannel, reqModel, reqModel.Id)
 
 		// get a response from the channel, render the results using ResponseWriter and log the data/error
 		// to the console as well.

--- a/plank/pkg/server/endpointer_handler_factory.go
+++ b/plank/pkg/server/endpointer_handler_factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"github.com/vmware/transport-go/bus"
 	"github.com/vmware/transport-go/model"
 	"github.com/vmware/transport-go/plank/utils"
@@ -58,10 +57,6 @@ func buildEndpointHandler(svcChannel string, reqBuilder service.RequestBuilder, 
 				} else {
 					respBody = response.Payload
 				}
-
-				utils.Log.WithFields(logrus.Fields{
-					//"payload": respBody, // don't show this, we may be sending around big byte arrays
-				}).Debugf("Response received from channel %s:", svcChannel)
 
 				// if our Message is an error and it has a code, lets send that back to the client.
 				if response.Error {

--- a/plank/pkg/server/endpointer_handler_factory_test.go
+++ b/plank/pkg/server/endpointer_handler_factory_test.go
@@ -16,46 +16,49 @@ import (
 func TestBuildEndpointHandler_Timeout(t *testing.T) {
 	b := bus.ResetBus()
 	service.ResetServiceRegistry()
+	msgChan := make(chan *model.Message, 1)
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 	assert.HTTPBodyContains(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
 		return model.Request{
 			Payload: nil,
 			Request: "test-request",
 		}
-	}, 5*time.Millisecond), "GET", "http://localhost", nil, "request timed out")
+	}, 5*time.Millisecond, msgChan), "GET", "http://localhost", nil, "request timed out")
 }
 
 func TestBuildEndpointHandler_ChanResponseErr(t *testing.T) {
 	b := bus.ResetBus()
 	service.ResetServiceRegistry()
+	msgChan := make(chan *model.Message, 1)
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 	assert.HTTPErrorf(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
 		uId := &uuid.UUID{}
-		_ = b.SendErrorMessage("test-chan", fmt.Errorf("test error"), uId)
+		msgChan <- &model.Message{Error: fmt.Errorf("test error")}
 		return model.Request{
 			Id:      uId,
 			Payload: nil,
 			Request: "test-request",
 		}
-	}, 5*time.Second), "GET", "http://localhost", nil, "test error")
+	}, 5*time.Second, msgChan), "GET", "http://localhost", nil, "test error")
 }
 
 func TestBuildEndpointHandler_SuccessResponse(t *testing.T) {
 	b := bus.ResetBus()
 	service.ResetServiceRegistry()
+	msgChan := make(chan *model.Message, 1)
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 	assert.HTTPBodyContains(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
 		uId := &uuid.UUID{}
-		_ = b.SendResponseMessage("test-chan", &model.Response{
+		msgChan <- &model.Message{Payload: &model.Response{
 			Id:      uId,
 			Payload: []byte("{\"error\": false}"),
-		}, uId)
+		}}
 		return model.Request{
 			Id:      uId,
 			Payload: nil,
 			Request: "test-request",
 		}
-	}, 5*time.Second), "GET", "http://localhost", nil, "{\"error\": false}")
+	}, 5*time.Second, msgChan), "GET", "http://localhost", nil, "{\"error\": false}")
 }
 
 func TestBuildEndpointHandler_ErrorResponse(t *testing.T) {
@@ -63,6 +66,7 @@ func TestBuildEndpointHandler_ErrorResponse(t *testing.T) {
 	service.ResetServiceRegistry()
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 
+	msgChan := make(chan *model.Message, 1)
 	uId := &uuid.UUID{}
 	rsp := &model.Response{
 		Id:        uId,
@@ -73,19 +77,20 @@ func TestBuildEndpointHandler_ErrorResponse(t *testing.T) {
 	expected, _ := json.Marshal(rsp.Payload)
 
 	assert.HTTPBodyContains(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
-		_ = b.SendResponseMessage("test-chan", rsp, uId)
+		msgChan <- &model.Message{Payload: rsp}
 		return model.Request{
 			Id:      uId,
 			Payload: nil,
 			Request: "test-request",
 		}
 
-	}, 5*time.Second), "GET", "http://localhost", nil, string(expected))
+	}, 5*time.Second, msgChan), "GET", "http://localhost", nil, string(expected))
 }
 
 func TestBuildEndpointHandler_ErrorResponseAlternative(t *testing.T) {
 	b := bus.ResetBus()
 	service.ResetServiceRegistry()
+	msgChan := make(chan *model.Message, 1)
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 
 	uId := &uuid.UUID{}
@@ -96,19 +101,20 @@ func TestBuildEndpointHandler_ErrorResponseAlternative(t *testing.T) {
 	}
 
 	assert.HTTPBodyContains(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
-		_ = b.SendResponseMessage("test-chan", rsp, uId)
+		msgChan <- &model.Message{Payload: rsp}
 		return model.Request{
 			Id:      uId,
 			Payload: nil,
 			Request: "test-request",
 		}
 
-	}, 5*time.Second), "GET", "http://localhost", nil, "418")
+	}, 5*time.Second, msgChan), "GET", "http://localhost", nil, "418")
 }
 
 func TestBuildEndpointHandler_CatchPanic(t *testing.T) {
 	b := bus.ResetBus()
 	service.ResetServiceRegistry()
+	msgChan := make(chan *model.Message, 1)
 	_ = b.GetChannelManager().CreateChannel("test-chan")
 	assert.HTTPBodyContains(t, buildEndpointHandler("test-chan", func(w http.ResponseWriter, r *http.Request) model.Request {
 		panic("peekaboo")
@@ -116,5 +122,5 @@ func TestBuildEndpointHandler_CatchPanic(t *testing.T) {
 			Payload: nil,
 			Request: "test-request",
 		}
-	}, 5*time.Second), "GET", "http://localhost", nil, "Internal Server Error")
+	}, 5*time.Second, msgChan), "GET", "http://localhost", nil, "Internal Server Error")
 }

--- a/plank/pkg/server/initialize.go
+++ b/plank/pkg/server/initialize.go
@@ -27,12 +27,11 @@ func (ps *platformServer) initialize() {
 	var err error
 
 	// initialize core components
-	var busInstance = bus.GetBus()
 	var serviceRegistryInstance = service.GetServiceRegistry()
 	var svcLifecycleManager = service.GetServiceLifecycleManager()
 
 	// create essential bus channels
-	busInstance.GetChannelManager().CreateChannel(PLANK_SERVER_ONLINE_CHANNEL)
+	ps.eventbus.GetChannelManager().CreateChannel(PLANK_SERVER_ONLINE_CHANNEL)
 
 	// initialize HTTP endpoint handlers map
 	ps.endpointHandlerMap = map[string]http.HandlerFunc{}
@@ -102,7 +101,7 @@ func (ps *platformServer) initialize() {
 	}
 
 	// set up a listener to receive REST bridge configs for services and set them up according to their specs
-	lcmChanHandler, err := busInstance.ListenStreamForDestination(service.LifecycleManagerChannelName, busInstance.GetId())
+	lcmChanHandler, err := ps.eventbus.ListenStreamForDestination(service.LifecycleManagerChannelName, ps.eventbus.GetId())
 	if err != nil {
 		utils.Log.Fatalln(err)
 	}
@@ -114,7 +113,7 @@ func (ps *platformServer) initialize() {
 		}
 
 		fabricSvc, _ := serviceRegistryInstance.GetService(request.ServiceChannel)
-		svcReadyStore := busInstance.GetStoreManager().GetStore(service.ServiceReadyStore)
+		svcReadyStore := ps.eventbus.GetStoreManager().GetStore(service.ServiceReadyStore)
 		hooks := svcLifecycleManager.GetServiceHooks(request.ServiceChannel)
 
 		if request.Override {
@@ -145,7 +144,7 @@ func (ps *platformServer) initialize() {
 
 	// create an internal bus channel to notify significant changes in sessions such as disconnect
 	if ps.serverConfig.FabricConfig != nil {
-		channelManager := busInstance.GetChannelManager()
+		channelManager := ps.eventbus.GetChannelManager()
 		channelManager.CreateChannel(bus.STOMP_SESSION_NOTIFY_CHANNEL)
 	}
 

--- a/plank/pkg/server/test_suite_harness.go
+++ b/plank/pkg/server/test_suite_harness.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/transport-go/bus"
 	"github.com/vmware/transport-go/model"
 	"github.com/vmware/transport-go/plank/utils"
-	"github.com/vmware/transport-go/service"
+	svc "github.com/vmware/transport-go/service"
 	"io/ioutil"
 	"net"
 	"os"
@@ -81,7 +81,7 @@ func GetBasicTestServerConfig(rootDir, outLog, accessLog, errLog string, port in
 
 // SetupPlankTestSuite will boot a new instance of plank on your chosen port and will also fire up your service
 // Ready to be tested. This always runs on localhost.
-func SetupPlankTestSuite(service service.FabricService, serviceChannel string, port int,
+func SetupPlankTestSuite(service svc.FabricService, serviceChannel string, port int,
 	config *PlatformServerConfig) (*PlankIntegrationTestSuite, error) {
 
 	s := &PlankIntegrationTestSuite{}
@@ -103,7 +103,8 @@ func SetupPlankTestSuite(service service.FabricService, serviceChannel string, p
 	s.Syschan = make(chan os.Signal, 1)
 	go s.PlatformServer.StartServer(s.Syschan)
 
-	s.EventBus = bus.GetBus()
+	s.EventBus = bus.ResetBus()
+	svc.ResetServiceRegistry()
 
 	// get a pointer to the channel manager
 	s.ChannelManager = s.EventBus.GetChannelManager()

--- a/plank/pkg/server/test_suite_harness_test.go
+++ b/plank/pkg/server/test_suite_harness_test.go
@@ -35,7 +35,8 @@ func (m *testPlankTestIntegration) SetBus(eventBus bus.EventBus) {
 }
 
 func TestSetupPlankTestSuiteForTest(t *testing.T) {
-	b := bus.GetBus()
+	b := bus.ResetBus()
+	service.ResetServiceRegistry()
 	cm := b.GetChannelManager()
 	pit := &PlankIntegrationTestSuite{
 		Suite:          suite.Suite{},

--- a/plank/utils/cli.go
+++ b/plank/utils/cli.go
@@ -71,17 +71,17 @@ var PlatformServerFlagConstants = map[string]map[string]string{
 	"OutputLog": {
 		"FlagName":    "output-log",
 		"ShortFlag":   "l",
-		"Description": "Platform log output",
+		"Description": "Platform log output. Possible values: stdout, stderr, null, or path to a file",
 	},
 	"AccessLog": {
 		"FlagName":    "access-log",
 		"ShortFlag":   "a",
-		"Description": "HTTP server access log output",
+		"Description": "HTTP server access log output. Possible values: stdout, stderr, null, or path to a file",
 	},
 	"ErrorLog": {
 		"FlagName":    "error-log",
 		"ShortFlag":   "e",
-		"Description": "HTTP server error log output",
+		"Description": "HTTP server error log output. Possible values: stdout, stderr, null, or path to a file",
 	},
 	"Debug": {
 		"FlagName":    "debug",

--- a/plank/utils/paths.go
+++ b/plank/utils/paths.go
@@ -55,7 +55,7 @@ func DeriveStaticURIFromPath(input string) (string, string) {
 
 func JoinBasePathIfRelativeRegularFilePath(base string, in string) (out string) {
 	out = in
-	if in == "stdout" || in == "stderr" {
+	if in == "stdout" || in == "stderr" || in == "null" {
 		return
 	}
 


### PR DESCRIPTION
During a benchmark test using `wrk` it was revealed that a REST
bridged service was significantly slower than comparable servers such
as Spring Boot. Profiling the server revealed that the ListenOnce()
method was causing a significant amount of overheads as it was being
called per HTTP request, thus generating a new message handler and
invoking once.Do() call involving mutex every single time.

The fix involves using the ListenStream() method to stop generating
excessive time and space overheads during the bridge process.
See the attached screenshots for comparsion between before and after
fix.

**Test service API endpoint**:
/api/date returns the current unix time

_Plank_:
![image](https://user-images.githubusercontent.com/3834071/139164877-24a4ab19-27f9-41e3-8557-30e9b5b1d6ff.png)

_Spring Boot_:
![image](https://user-images.githubusercontent.com/3834071/139164903-b0372380-2192-4c36-baa1-a846cd16006b.png)

**Before fix**:
![image](https://user-images.githubusercontent.com/3834071/139159601-19209cd9-60fc-48bb-809a-0455c4890dc8.png)

**After fix**:
![image](https://user-images.githubusercontent.com/3834071/139159743-8079c269-321e-4c1c-9e50-fe229da0ca3e.png)

**Spring Boot 2.5.6**:
![image](https://user-images.githubusercontent.com/3834071/139159842-f4039f87-e454-427c-bf4d-860be9ca9000.png)

Signed-off-by: Josh Kim <kjosh@vmware.com>