### PR TITLE
new: Add method to Message to cast to a given type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/prometheus/client_golang v1.6.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/model/message.go
+++ b/model/message.go
@@ -3,32 +3,61 @@
 
 package model
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"reflect"
+)
 
 // Direction int defining which way messages are travelling on a Channel.
 type Direction int
 
 const (
-    RequestDir  Direction = 0
-    ResponseDir Direction = 1
-    ErrorDir    Direction = 2
+	RequestDir  Direction = 0
+	ResponseDir Direction = 1
+	ErrorDir    Direction = 2
 )
 
 // A Message is the encapsulation of the event sent on the bus.
 // It holds a Direction, errors, a Payload and more.
 type Message struct {
-    Id            *uuid.UUID      `json:"id"`            // message identifier
-    DestinationId *uuid.UUID      `json:"destinationId"` // destinationId (targeted recipient)
-    Channel       string          `json:"channel"`       // reference to channel message was sent on.
-    Destination   string          `json:"channel"`       // destination message was sent to (if galactic)
-    Payload       interface{}     `json:"payload"`
-    Error         error           `json:"error"`
-    Direction     Direction       `json:"direction"`
-    Headers       []MessageHeader `json:"headers"`
+	Id            *uuid.UUID      `json:"id"`            // message identifier
+	DestinationId *uuid.UUID      `json:"destinationId"` // destinationId (targeted recipient)
+	Channel       string          `json:"channel"`       // reference to channel message was sent on.
+	Destination   string          `json:"destination"`   // destination message was sent to (if galactic)
+	Payload       interface{}     `json:"payload"`
+	Error         error           `json:"error"`
+	Direction     Direction       `json:"direction"`
+	Headers       []MessageHeader `json:"headers"`
 }
 
 // A Message header can contain any meta data.
 type MessageHeader struct {
-    Label string
-    Value string
+	Label string
+	Value string
+}
+
+// CastPayloadToType converts the raw interface{} typed Payload into the
+// specified object passed as an argument.
+func (m *Message) CastPayloadToType(typ interface{}) error {
+	var unwrappedResponse Response
+
+	// nil-check
+	typVal := reflect.ValueOf(typ)
+	if typVal.Kind() != reflect.Ptr {
+		return fmt.Errorf("CastPayloadToType: invalid argument. argument should be the address of an object")
+	}
+
+	if typVal.IsNil() {
+		return fmt.Errorf("CastPayloadToType: cannot cast to nil")
+	}
+
+	// unwrap payload first
+	if err := json.Unmarshal(m.Payload.([]byte), &unwrappedResponse); err != nil {
+		return fmt.Errorf("CastPayloadToType: failed to unmarshal payload %v: %w", m.Payload, err)
+	}
+
+	return mapstructure.Decode(unwrappedResponse.Payload, typ)
 }

--- a/model/message_test.go
+++ b/model/message_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMessage_CastPayloadToType_HappyPath(t *testing.T) {
+	// arrange
+	msg := getNewTestMessage()
+	var dest Request
+
+	// act
+	err := msg.CastPayloadToType(&dest)
+
+	// assert
+	assert.Nil(t, err)
+	assert.EqualValues(t, "dummy-value-coming-through", dest.Request)
+}
+
+func TestMessage_CastPayloadToType_BadPayload(t *testing.T) {
+	// arrange
+	msg := getNewTestMessage()
+	pb := msg.Payload.([]byte)
+	pb = append([]byte("random_bytes"), pb...)
+	msg.Payload = pb
+	var dest Request
+
+	// act
+	err := msg.CastPayloadToType(&dest)
+
+	// assert
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal payload")
+	assert.NotEqual(t, "dummy-value-coming-through", dest.Request)
+}
+
+func TestMessage_CastPayloadToType_NonPointer(t *testing.T) {
+	// arrange
+	msg := getNewTestMessage()
+	var dest Request
+
+	// act
+	err := msg.CastPayloadToType(dest)
+
+	// assert
+	assert.NotNil(t, err)
+	assert.NotEqual(t, "dummy-value-coming-through", dest.Request)
+}
+
+func TestMessage_CastPayloadToType_NilPointer(t *testing.T) {
+	// arrange
+	msg := getNewTestMessage()
+	var dest *Request
+
+	// act
+	err := msg.CastPayloadToType(dest)
+
+	// assert
+	assert.NotNil(t, err)
+	assert.Nil(t, dest)
+}
+
+func getNewTestMessage() *Message {
+	rspPayload := &Response{
+		Id:      &uuid.UUID{},
+		Payload: Request{Request: "dummy-value-coming-through"},
+	}
+
+	jsonEncoded, _ := json.Marshal(rspPayload)
+	return &Message{
+		Id:      &uuid.UUID{},
+		Channel: "test",
+		Payload: jsonEncoded,
+	}
+}


### PR DESCRIPTION
This PR adds a new method to the `Message` object that allows the casting of the message's payload into an arbitrary type. This is particularly useful for the callback to a message handler function where usually the actual payload the user wants to consume in their app is buried under the following structure:

```
Message {
    ...
    Payload {
        ...
        Response {
            ...
            Payload {           <-- this is the actual payload
                ...
            }
    }
}
```

Using this method on the message object it belongs to will strip all wrapping structure and return the actual payload straight. A usage example is as follows:

```go
handler.Handle(func(msg *model.Message) {
    var value SomeStruct
    if err := msg.CastPayloadToType(&value); err != nil {
        utils.Log.Errorf("error extracting payload from response: %v", err.Error())
    }
})
```

Signed-off-by: Josh Kim <kjosh@vmware.com>