### PR TITLE
Disable boot image by default

### DIFF
--- a/plank/README.md
+++ b/plank/README.md
@@ -64,19 +64,14 @@ Now we're ready to start the application. To kick off the server using the demo 
 ```bash
 ./build/plank start-server --config-file config.json
 
- ______ __      ______  __   __  __  __    
-/\  == /\ \    /\  __ \/\ "-.\ \/\ \/ /    
-\ \  _-\ \ \___\ \  __ \ \ \-.  \ \  _"-.  
- \ \_\  \ \_____\ \_\ \_\ \_\\"\_\ \_\ \_\ 
-  \/_/   \/_____/\/_/\/_/\/_/ \/_/\/_/\/_/ 
-                                           
-Host			localhost
-Port			30080
-Fabric endpoint		/ws
-SPA endpoint		/public
-SPA static assets	/assets
-Health endpoint		/health
-Prometheus endpoint	/prometheus
+ P L A N K
+Host                    localhost
+Port                    30080
+Fabric endpoint         /ws
+SPA endpoint            /
+SPA static assets       /assets
+Health endpoint         /health
+Prometheus endpoint     /prometheus
 ...
 time="2021-08-17T13:28:15-07:00" level=info msg="Service '*services.StockTickerService' initialized successfully" fileName=initialize.go goroutine=44 package=server
 time="2021-08-17T13:28:15-07:00" level=info msg="Service channel 'stock-ticker-service' is now bridged to a REST endpoint /rest/stock-ticker/{symbol} (GET)\n" fileName=server.go goroutine=44 package=server
@@ -89,13 +84,18 @@ type `curl -k https://localhost:30080/rest/stock-ticker/VMW` in Terminal if you 
 and accept the self-signed certificate warning. You will be served a page that shows the latest stock price
 for VMware, Inc. Try and swap out `VMW` with another symbol of your choice to further test it out!
 
+If you navigate to the root at https://localhost:30080, you'll be greeted with a 404!
+This is an expected behavior, as the demo app does not serve anything at root `/`, but we will
+consider changing the default 404 screen to something that is informational or more appealing at least.
+
 > NOTE: The sample service is using a loosely gated third party API which imposes
 > a substantial limit on how many calls you can make per minute and per day in return for making
 > the service free to all.
 
-> NOTE: If you navigate to the root at https://localhost:30080, you'll be greeted with a 404!
-> This is an expected behavior, as the demo app does not serve anything at root `/`, but we will
-> consider changing the default 404 screen to something that is informational or more appealing at least.
+> NOTE: Plank, when started, can boot up with a nice image of a wooden plank
+> as a splash screen, but it's disabled by default because of a few reasons like unnecessarily
+> adding to the binary size and generally being a bloat to some consumers. If you want
+> to see it though, build your app with `--tags boot_img` custom tag.
 
 ## All supported flags and usages
 

--- a/plank/pkg/server/banner.go
+++ b/plank/pkg/server/banner.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"embed"
 	"fmt"
 	imgcolor "image/color"
 	"os"
@@ -12,16 +11,16 @@ import (
 	"github.com/vmware/transport-go/plank/utils"
 )
 
-//go:embed logo.png
-var logoFs embed.FS
-
 // printBanner prints out banner as well as brief server config
 func (ps *platformServer) printBanner() {
 	// print out ascii art only if output is stdout
 	if ps.out == os.Stdout {
-		_, _ = fmt.Fprintf(ps.out, "\n\n")
-		fs, _ := logoFs.Open("logo.png")
+		fs, err := logoFs.Open("logo.png")
+		if err != nil {
+			goto bannerBody
+		}
 		defer fs.Close()
+		_, _ = fmt.Fprintf(ps.out, "\n\n")
 		img, err := ansimage.NewScaledFromReader(
 			fs,
 			40,
@@ -38,6 +37,7 @@ func (ps *platformServer) printBanner() {
 	}
 
 	// display title and config summary
+bannerBody:
 	_, _ = fmt.Fprintln(ps.out)
 	color.Set(color.BgHiWhite, color.FgHiBlack, color.Bold)
 	_, _ = fmt.Fprintf(ps.out, " P L A N K ")

--- a/plank/pkg/server/banner_fs.go
+++ b/plank/pkg/server/banner_fs.go
@@ -1,0 +1,9 @@
+//go:build boot_img
+// +build boot_img
+
+package server
+
+import "embed"
+
+//go:embed logo.png
+var logoFs embed.FS

--- a/plank/pkg/server/banner_fs_default.go
+++ b/plank/pkg/server/banner_fs_default.go
@@ -1,0 +1,8 @@
+//go:build !boot_img
+// +build !boot_img
+
+package server
+
+import "embed"
+
+var logoFs embed.FS


### PR DESCRIPTION
Consuming ~700kB just for the purpose of showing a splash image is not
a good idea for a library, hence disabling it by default and making it
an opt-in feature. Use `--tags boot_img` in `go build` or `go run`
to opt in.

Signed-off-by: Josh Kim <kjosh@vmware.com>