### PR TITLE
Improve response payload casting operation

### DIFF
--- a/service/rest_service.go
+++ b/service/rest_service.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 )
 
 const (
@@ -92,6 +93,15 @@ func (rs *restService) HandleServiceRequest(request *model.Request, core FabricS
 	// add default Content-Type header if such is not provided in the request
 	if httpReq.Header.Get("Content-Type") == "" {
 		httpReq.Header.Add("Content-Type", "application/merge-patch+json")
+	}
+
+	contentType := httpReq.Header.Get("Content-Type")
+	if strings.Contains(contentType, "json") {
+		// leaving restReq.ResponseType empty is equivalent to treating the response as JSON. see deserializeResponse().
+	} else {
+		// otherwise default to byte slice. note that we have an arm for the string type, but defaulting to the byte
+		// slice makes the payload more flexible to handle in downstream consumers
+		restReq.ResponseType = reflect.TypeOf([]byte{})
 	}
 
 	httpResp, err := rs.httpClient.Do(httpReq)


### PR DESCRIPTION
`model.Message` struct has a method `CastPayloadToType` used to
conveniently cast `Message.Payload.(Response).Payload` into the type of
the provided argument. The current implementation had a few gaps that
made the method only viaible in situations where `Message.Payload`
were yet to be unmarshalled (e.g. `interface{} | []byte`).

This PR also fixes a bug in rest_service.go where `RestServiceRequest.ResponseType`
was never customizable, leading to the response body to be always
treated like a JSON-decodable structure. This would cause HTTP calls
whose response type is not of JSON to throw errors. By only
deserializing the body for which the request header `Content-Type` is
of JSON type and passing others as raw byte slices, the RestService
callers can handle response payloads of arbitrary MIME types.

Signed-off-by: Josh Kim <kjosh@vmware.com>