### PR TITLE
Bump golang.org/x/net to fix remaining lib-induced vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.1
 	golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
+	golang.org/x/net v0.7.0
 )
 
 require (
@@ -68,7 +68,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.1.0 // indirect
+	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect


### PR DESCRIPTION
This PR fixes three more vulnerabilities stemming from an old version of `golang.org/x/net` by bumping it to a version that includes a fix.

Signed-off-by: Josh Kim <kjosh@vmware.com>